### PR TITLE
feat: add watch command and logs -f flag for real-time streaming

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -110,10 +110,26 @@ func main() {
 
 	case "logs":
 		if len(os.Args) < 3 {
-			fmt.Println("Usage: agentctl logs <name>")
+			fmt.Println("Usage: agentctl logs [-f] <name>")
 			os.Exit(1)
 		}
-		container.Logs(os.Args[2])
+		// Check for -f flag
+		if os.Args[2] == "-f" {
+			if len(os.Args) < 4 {
+				fmt.Println("Usage: agentctl logs -f <name>")
+				os.Exit(1)
+			}
+			container.LogsFollow(os.Args[3])
+		} else {
+			container.Logs(os.Args[2])
+		}
+
+	case "watch":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: agentctl watch <name>")
+			os.Exit(1)
+		}
+		container.Watch(os.Args[2])
 
 	case "shell":
 		if len(os.Args) < 3 {
@@ -136,13 +152,15 @@ func printUsage() {
 	fmt.Println("  check <name>                    Check if agent's task is complete")
 	fmt.Println("  list                            List all agents with status")
 	fmt.Println("  status <name>                   Show agent details")
-	fmt.Println("  logs <name>                     Show Claude logs from agent")
+	fmt.Println("  logs [-f] <name>                Show Claude logs (-f to follow in real-time)")
+	fmt.Println("  watch <name>                    Stream Claude's activity in real-time")
 	fmt.Println("  shell <name>                    Open shell in agent container")
 	fmt.Println("  kill <name>                     Stop and remove agent")
 	fmt.Println()
 	fmt.Println("Example:")
 	fmt.Println("  agentctl spawn fix-bug https://github.com/user/repo feature-branch")
 	fmt.Println("  agentctl run fix-bug 'Fix the failing tests in src/auth.go'")
+	fmt.Println("  agentctl watch fix-bug")
 	fmt.Println("  agentctl check fix-bug")
 	fmt.Println("  agentctl kill fix-bug")
 }

--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -145,6 +145,21 @@ func Logs(name string) error {
 	return cmd.Run()
 }
 
+// LogsFollow streams Claude logs from the agent in real-time using tail -f
+func LogsFollow(name string) error {
+	cmd := exec.Command("podman", "exec", name, "tail", "-f", "/home/agent/claude.log")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Watch streams Claude's activity in real-time (alias for LogsFollow)
+func Watch(name string) error {
+	fmt.Printf("Watching agent %s (Ctrl+C to stop)...\n", name)
+	fmt.Println("---")
+	return LogsFollow(name)
+}
+
 // Shell opens an interactive shell in the agent container
 func Shell(name string) error {
 	cmd := exec.Command("podman", "exec", "-it", name, "/bin/bash")


### PR DESCRIPTION
## Summary

- Add new `watch` command to stream Claude's activity in real-time
- Add `-f` flag to `logs` command for following output (like `tail -f`)
- Both commands use `podman exec` with `tail -f` to stream `/home/agent/claude.log`

## Changes

- **cmd/agentctl/main.go**: Added `watch` case and modified `logs` to support `-f` flag
- **pkg/container/agent.go**: Added `LogsFollow()` and `Watch()` functions

## Usage

```bash
# Stream Claude's activity in real-time
agentctl watch my-agent

# Alternative using logs -f
agentctl logs -f my-agent
```

## Test plan

- [ ] Spawn an agent container with `agentctl spawn`
- [ ] Run `agentctl watch <name>` and verify logs stream in real-time
- [ ] Run `agentctl logs -f <name>` and verify same behavior
- [ ] Verify Ctrl+C properly terminates the stream
- [ ] Verify `agentctl logs <name>` (without -f) still works as before

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `-f` flag to logs command for real-time log streaming
  * Introduced new `watch` command to monitor real-time container activity
  * Updated help documentation and usage text to reflect new command syntax and options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->