### PR TITLE
feat: add agent coordination via shared message bus

### DIFF
--- a/pkg/coordination/bus.go
+++ b/pkg/coordination/bus.go
@@ -1,0 +1,166 @@
+package coordination
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// MessageType represents the type of coordination message.
+type MessageType string
+
+const (
+	MsgClaim        MessageType = "claim"
+	MsgRelease      MessageType = "release"
+	MsgCommitted    MessageType = "committed"
+	MsgPushed       MessageType = "pushed"
+	MsgPRCreated    MessageType = "pr_created"
+	MsgMerged       MessageType = "merged"
+	MsgRebaseNeeded MessageType = "rebase_needed"
+)
+
+// Message represents a single coordination message on the bus.
+type Message struct {
+	Type      MessageType       `json:"type"`
+	Agent     string            `json:"agent"`
+	Timestamp time.Time         `json:"timestamp"`
+	Data      map[string]string `json:"data,omitempty"`
+}
+
+// Publish appends a message to the bus (messages.jsonl).
+func Publish(repoURL string, msg Message) error {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return err
+	}
+
+	msg.Timestamp = time.Now()
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("cannot marshal message: %w", err)
+	}
+	data = append(data, '\n')
+
+	messagesPath := filepath.Join(dir, "messages.jsonl")
+	f, err := os.OpenFile(messagesPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot open messages.jsonl: %w", err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(data)
+	return err
+}
+
+// ReadMessages reads all messages from the bus.
+func ReadMessages(repoURL string) ([]Message, error) {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return readMessagesFromDir(dir)
+}
+
+// ReadMessagesSince reads messages from the bus that occurred after the given time.
+func ReadMessagesSince(repoURL string, since time.Time) ([]Message, error) {
+	all, err := ReadMessages(repoURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []Message
+	for _, msg := range all {
+		if msg.Timestamp.After(since) {
+			filtered = append(filtered, msg)
+		}
+	}
+	return filtered, nil
+}
+
+// ReadMessagesForAgent reads messages relevant to a specific agent.
+func ReadMessagesForAgent(repoURL, agentName string) ([]Message, error) {
+	all, err := ReadMessages(repoURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []Message
+	for _, msg := range all {
+		// Include messages FROM this agent and messages that affect this agent
+		if msg.Agent == agentName || isRelevantToAgent(msg, agentName) {
+			filtered = append(filtered, msg)
+		}
+	}
+	return filtered, nil
+}
+
+// HasRebaseNeeded checks if any rebase_needed message exists for the given agent
+// since the specified time.
+func HasRebaseNeeded(repoURL, agentName string, since time.Time) (bool, error) {
+	msgs, err := ReadMessagesSince(repoURL, since)
+	if err != nil {
+		return false, err
+	}
+
+	for _, msg := range msgs {
+		if msg.Type == MsgRebaseNeeded {
+			// Check if this rebase message targets this agent
+			if target, ok := msg.Data["target"]; ok && target == agentName {
+				return true, nil
+			}
+			// Or if it's a broadcast rebase_needed (no specific target)
+			if _, ok := msg.Data["target"]; !ok {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func readMessagesFromDir(dir string) ([]Message, error) {
+	messagesPath := filepath.Join(dir, "messages.jsonl")
+	f, err := os.Open(messagesPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("cannot open messages.jsonl: %w", err)
+	}
+	defer f.Close()
+
+	var messages []Message
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var msg Message
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue // skip malformed lines
+		}
+		messages = append(messages, msg)
+	}
+
+	return messages, scanner.Err()
+}
+
+// isRelevantToAgent checks if a message is relevant to a specific agent.
+// Broadcast messages (like rebase_needed without a target) are relevant to all.
+func isRelevantToAgent(msg Message, agentName string) bool {
+	if msg.Type == MsgRebaseNeeded {
+		target, ok := msg.Data["target"]
+		return !ok || target == agentName
+	}
+	// pushed/committed/merged events are relevant to all agents on the same repo
+	switch msg.Type {
+	case MsgPushed, MsgMerged:
+		return true
+	}
+	return false
+}

--- a/pkg/coordination/bus_test.go
+++ b/pkg/coordination/bus_test.go
@@ -1,0 +1,212 @@
+package coordination
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestPublishAndReadMessages(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	msg := Message{
+		Type:  MsgCommitted,
+		Agent: "agent-1",
+		Data:  map[string]string{"sha": "abc123"},
+	}
+
+	if err := Publish(repoURL, msg); err != nil {
+		t.Fatalf("Publish failed: %v", err)
+	}
+
+	msgs, err := ReadMessages(repoURL)
+	if err != nil {
+		t.Fatalf("ReadMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	if msgs[0].Type != MsgCommitted {
+		t.Errorf("expected type committed, got %s", msgs[0].Type)
+	}
+	if msgs[0].Agent != "agent-1" {
+		t.Errorf("expected agent agent-1, got %s", msgs[0].Agent)
+	}
+	if msgs[0].Data["sha"] != "abc123" {
+		t.Errorf("expected sha abc123, got %s", msgs[0].Data["sha"])
+	}
+	if msgs[0].Timestamp.IsZero() {
+		t.Error("timestamp should be set")
+	}
+}
+
+func TestPublishMultipleMessages(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	types := []MessageType{MsgCommitted, MsgPushed, MsgPRCreated}
+	for _, mt := range types {
+		Publish(repoURL, Message{Type: mt, Agent: "agent-1"})
+	}
+
+	msgs, _ := ReadMessages(repoURL)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	for i, mt := range types {
+		if msgs[i].Type != mt {
+			t.Errorf("message %d: expected type %s, got %s", i, mt, msgs[i].Type)
+		}
+	}
+}
+
+func TestReadMessagesSince(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	Publish(repoURL, Message{Type: MsgCommitted, Agent: "agent-1"})
+
+	cutoff := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	Publish(repoURL, Message{Type: MsgPushed, Agent: "agent-1"})
+
+	msgs, err := ReadMessagesSince(repoURL, cutoff)
+	if err != nil {
+		t.Fatalf("ReadMessagesSince failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message since cutoff, got %d", len(msgs))
+	}
+	if msgs[0].Type != MsgPushed {
+		t.Errorf("expected pushed, got %s", msgs[0].Type)
+	}
+}
+
+func TestReadMessagesForAgent(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	Publish(repoURL, Message{Type: MsgCommitted, Agent: "agent-1"})
+	Publish(repoURL, Message{Type: MsgCommitted, Agent: "agent-2"})
+	Publish(repoURL, Message{Type: MsgPushed, Agent: "agent-2"}) // broadcast, relevant to all
+
+	msgs, err := ReadMessagesForAgent(repoURL, "agent-1")
+	if err != nil {
+		t.Fatalf("ReadMessagesForAgent failed: %v", err)
+	}
+	// agent-1's own committed + agent-2's pushed (broadcast)
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 messages for agent-1, got %d", len(msgs))
+	}
+}
+
+func TestHasRebaseNeeded(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	since := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	// No rebase needed initially
+	needed, err := HasRebaseNeeded(repoURL, "agent-1", since)
+	if err != nil {
+		t.Fatalf("HasRebaseNeeded failed: %v", err)
+	}
+	if needed {
+		t.Error("should not need rebase initially")
+	}
+
+	// Broadcast rebase_needed
+	Publish(repoURL, Message{Type: MsgRebaseNeeded, Agent: "agent-2"})
+
+	needed, _ = HasRebaseNeeded(repoURL, "agent-1", since)
+	if !needed {
+		t.Error("should need rebase after broadcast")
+	}
+}
+
+func TestHasRebaseNeededTargeted(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	since := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	// Targeted rebase for agent-1 only
+	Publish(repoURL, Message{
+		Type:  MsgRebaseNeeded,
+		Agent: "agent-2",
+		Data:  map[string]string{"target": "agent-1"},
+	})
+
+	needed, _ := HasRebaseNeeded(repoURL, "agent-1", since)
+	if !needed {
+		t.Error("agent-1 should need rebase")
+	}
+
+	needed, _ = HasRebaseNeeded(repoURL, "agent-3", since)
+	if needed {
+		t.Error("agent-3 should not need rebase (not targeted)")
+	}
+}
+
+func TestReadMessagesEmpty(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	msgs, err := ReadMessages(repoURL)
+	if err != nil {
+		t.Fatalf("ReadMessages on empty bus failed: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages on empty bus, got %d", len(msgs))
+	}
+}
+
+func TestMessageTypes(t *testing.T) {
+	// Verify all expected message types exist
+	types := []MessageType{
+		MsgClaim, MsgRelease, MsgCommitted,
+		MsgPushed, MsgPRCreated, MsgMerged, MsgRebaseNeeded,
+	}
+	expected := []string{
+		"claim", "release", "committed",
+		"pushed", "pr_created", "merged", "rebase_needed",
+	}
+	for i, mt := range types {
+		if string(mt) != expected[i] {
+			t.Errorf("expected %s, got %s", expected[i], mt)
+		}
+	}
+}

--- a/pkg/coordination/claims.go
+++ b/pkg/coordination/claims.go
@@ -1,0 +1,177 @@
+package coordination
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Claim represents a file claim by an agent.
+type Claim struct {
+	Agent     string    `json:"agent"`
+	File      string    `json:"file"`
+	ClaimedAt time.Time `json:"claimed_at"`
+}
+
+// Claims is a map from file path to the Claim holding it.
+type Claims map[string]*Claim
+
+// ClaimFile attempts to claim a file for the given agent.
+// Returns an error if the file is already claimed by another agent.
+func ClaimFile(repoURL, agentName, filePath string) error {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return err
+	}
+
+	claims, err := loadClaims(dir)
+	if err != nil {
+		return err
+	}
+
+	if existing, ok := claims[filePath]; ok {
+		if existing.Agent != agentName {
+			return fmt.Errorf("file %s already claimed by agent %s (since %s)",
+				filePath, existing.Agent, existing.ClaimedAt.Format(time.RFC3339))
+		}
+		// Already claimed by same agent, idempotent
+		return nil
+	}
+
+	claims[filePath] = &Claim{
+		Agent:     agentName,
+		File:      filePath,
+		ClaimedAt: time.Now(),
+	}
+
+	if err := saveClaims(dir, claims); err != nil {
+		return err
+	}
+
+	// Publish a claim message on the bus
+	return Publish(repoURL, Message{
+		Type:  MsgClaim,
+		Agent: agentName,
+		Data:  map[string]string{"file": filePath},
+	})
+}
+
+// ReleaseFile releases a file claim for the given agent.
+// Returns an error if the file is claimed by a different agent.
+func ReleaseFile(repoURL, agentName, filePath string) error {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return err
+	}
+
+	claims, err := loadClaims(dir)
+	if err != nil {
+		return err
+	}
+
+	existing, ok := claims[filePath]
+	if !ok {
+		// Not claimed, nothing to do
+		return nil
+	}
+
+	if existing.Agent != agentName {
+		return fmt.Errorf("file %s is claimed by agent %s, not %s",
+			filePath, existing.Agent, agentName)
+	}
+
+	delete(claims, filePath)
+
+	if err := saveClaims(dir, claims); err != nil {
+		return err
+	}
+
+	// Publish a release message on the bus
+	return Publish(repoURL, Message{
+		Type:  MsgRelease,
+		Agent: agentName,
+		Data:  map[string]string{"file": filePath},
+	})
+}
+
+// ListClaims returns all current file claims.
+func ListClaims(repoURL string) (Claims, error) {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return nil, err
+	}
+	return loadClaims(dir)
+}
+
+// IsFileClaimed checks if a file is claimed by any agent.
+// Returns the claiming agent name (empty if unclaimed) and whether it's claimed.
+func IsFileClaimed(repoURL, filePath string) (string, bool, error) {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return "", false, err
+	}
+
+	claims, err := loadClaims(dir)
+	if err != nil {
+		return "", false, err
+	}
+
+	if claim, ok := claims[filePath]; ok {
+		return claim.Agent, true, nil
+	}
+	return "", false, nil
+}
+
+// ReleaseAllForAgent releases all claims held by a given agent.
+func ReleaseAllForAgent(repoURL, agentName string) error {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return err
+	}
+
+	claims, err := loadClaims(dir)
+	if err != nil {
+		return err
+	}
+
+	for file, claim := range claims {
+		if claim.Agent == agentName {
+			delete(claims, file)
+		}
+	}
+
+	return saveClaims(dir, claims)
+}
+
+func loadClaims(dir string) (Claims, error) {
+	claimsPath := filepath.Join(dir, "claims.json")
+	data, err := os.ReadFile(claimsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(Claims), nil
+		}
+		return nil, fmt.Errorf("cannot read claims.json: %w", err)
+	}
+
+	var claims Claims
+	if err := json.Unmarshal(data, &claims); err != nil {
+		return nil, fmt.Errorf("cannot parse claims.json: %w", err)
+	}
+
+	if claims == nil {
+		claims = make(Claims)
+	}
+	return claims, nil
+}
+
+func saveClaims(dir string, claims Claims) error {
+	claimsPath := filepath.Join(dir, "claims.json")
+	data, err := json.MarshalIndent(claims, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal claims: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(claimsPath, data, 0644)
+}

--- a/pkg/coordination/claims_test.go
+++ b/pkg/coordination/claims_test.go
@@ -1,0 +1,166 @@
+package coordination
+
+import (
+	"os"
+	"testing"
+)
+
+func setupTestRepo(t *testing.T) (string, func()) {
+	t.Helper()
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	return repoURL, func() { os.RemoveAll(dir) }
+}
+
+func TestClaimFile(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	err := ClaimFile(repoURL, "agent-1", "src/main.go")
+	if err != nil {
+		t.Fatalf("ClaimFile failed: %v", err)
+	}
+
+	// Verify claim exists
+	claims, err := ListClaims(repoURL)
+	if err != nil {
+		t.Fatalf("ListClaims failed: %v", err)
+	}
+	if len(claims) != 1 {
+		t.Fatalf("expected 1 claim, got %d", len(claims))
+	}
+	if claims["src/main.go"].Agent != "agent-1" {
+		t.Error("claim should be held by agent-1")
+	}
+}
+
+func TestClaimFileIdempotent(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Claiming the same file twice by the same agent should succeed
+	if err := ClaimFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("first claim failed: %v", err)
+	}
+	if err := ClaimFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("idempotent claim failed: %v", err)
+	}
+}
+
+func TestClaimFileConflict(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	if err := ClaimFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("first claim failed: %v", err)
+	}
+
+	// Different agent claiming same file should fail
+	err := ClaimFile(repoURL, "agent-2", "src/main.go")
+	if err == nil {
+		t.Error("expected error when different agent claims same file")
+	}
+}
+
+func TestReleaseFile(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	if err := ClaimFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("claim failed: %v", err)
+	}
+
+	if err := ReleaseFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+
+	claims, err := ListClaims(repoURL)
+	if err != nil {
+		t.Fatalf("ListClaims failed: %v", err)
+	}
+	if len(claims) != 0 {
+		t.Errorf("expected 0 claims after release, got %d", len(claims))
+	}
+}
+
+func TestReleaseFileWrongAgent(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	if err := ClaimFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("claim failed: %v", err)
+	}
+
+	err := ReleaseFile(repoURL, "agent-2", "src/main.go")
+	if err == nil {
+		t.Error("expected error when wrong agent releases file")
+	}
+}
+
+func TestReleaseUnclaimedFile(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Releasing an unclaimed file should succeed (no-op)
+	if err := ReleaseFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("releasing unclaimed file should not error: %v", err)
+	}
+}
+
+func TestIsFileClaimed(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Initially unclaimed
+	agent, claimed, err := IsFileClaimed(repoURL, "src/main.go")
+	if err != nil {
+		t.Fatalf("IsFileClaimed failed: %v", err)
+	}
+	if claimed {
+		t.Error("file should not be claimed initially")
+	}
+	if agent != "" {
+		t.Error("agent should be empty when unclaimed")
+	}
+
+	// Claim it
+	if err := ClaimFile(repoURL, "agent-1", "src/main.go"); err != nil {
+		t.Fatalf("claim failed: %v", err)
+	}
+
+	agent, claimed, err = IsFileClaimed(repoURL, "src/main.go")
+	if err != nil {
+		t.Fatalf("IsFileClaimed failed: %v", err)
+	}
+	if !claimed {
+		t.Error("file should be claimed")
+	}
+	if agent != "agent-1" {
+		t.Errorf("expected agent-1, got %s", agent)
+	}
+}
+
+func TestReleaseAllForAgent(t *testing.T) {
+	repoURL, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Claim multiple files
+	ClaimFile(repoURL, "agent-1", "file1.go")
+	ClaimFile(repoURL, "agent-1", "file2.go")
+	ClaimFile(repoURL, "agent-2", "file3.go")
+
+	if err := ReleaseAllForAgent(repoURL, "agent-1"); err != nil {
+		t.Fatalf("ReleaseAllForAgent failed: %v", err)
+	}
+
+	claims, _ := ListClaims(repoURL)
+	if len(claims) != 1 {
+		t.Errorf("expected 1 claim remaining, got %d", len(claims))
+	}
+	if _, ok := claims["file3.go"]; !ok {
+		t.Error("agent-2's claim should still exist")
+	}
+}

--- a/pkg/coordination/coordination.go
+++ b/pkg/coordination/coordination.go
@@ -1,0 +1,70 @@
+// Package coordination provides a shared file-based message bus for agent coordination.
+// It manages file claims, inter-agent messaging, and shared state via a coordination
+// directory at ~/.agentctl/coordination/<repo-hash>/.
+package coordination
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CoordDir returns the coordination directory for a given repo path.
+// The directory is at ~/.agentctl/coordination/<repo-hash>/.
+func CoordDir(repoURL string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	hash := repoHash(repoURL)
+	dir := filepath.Join(home, ".agentctl", "coordination", hash)
+	return dir, nil
+}
+
+// Init creates the coordination directory structure and initializes
+// claims.json, messages.jsonl, and state.json if they don't exist.
+func Init(repoURL string) (string, error) {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("cannot create coordination directory: %w", err)
+	}
+
+	// Initialize claims.json if it doesn't exist
+	claimsPath := filepath.Join(dir, "claims.json")
+	if _, err := os.Stat(claimsPath); os.IsNotExist(err) {
+		if err := os.WriteFile(claimsPath, []byte("{}\n"), 0644); err != nil {
+			return "", fmt.Errorf("cannot create claims.json: %w", err)
+		}
+	}
+
+	// Initialize messages.jsonl if it doesn't exist
+	messagesPath := filepath.Join(dir, "messages.jsonl")
+	if _, err := os.Stat(messagesPath); os.IsNotExist(err) {
+		if err := os.WriteFile(messagesPath, []byte(""), 0644); err != nil {
+			return "", fmt.Errorf("cannot create messages.jsonl: %w", err)
+		}
+	}
+
+	// Initialize state.json if it doesn't exist
+	statePath := filepath.Join(dir, "state.json")
+	if _, err := os.Stat(statePath); os.IsNotExist(err) {
+		initial := `{"agents":{},"last_updated":""}` + "\n"
+		if err := os.WriteFile(statePath, []byte(initial), 0644); err != nil {
+			return "", fmt.Errorf("cannot create state.json: %w", err)
+		}
+	}
+
+	return dir, nil
+}
+
+// repoHash returns a short SHA-256 hash (first 12 chars) of the repo URL.
+func repoHash(repoURL string) string {
+	h := sha256.Sum256([]byte(repoURL))
+	return hex.EncodeToString(h[:])[:12]
+}

--- a/pkg/coordination/coordination_test.go
+++ b/pkg/coordination/coordination_test.go
@@ -1,0 +1,80 @@
+package coordination
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRepoHash(t *testing.T) {
+	hash1 := repoHash("https://github.com/user/repo1")
+	hash2 := repoHash("https://github.com/user/repo2")
+
+	if hash1 == hash2 {
+		t.Error("different repos should produce different hashes")
+	}
+
+	if len(hash1) != 12 {
+		t.Errorf("hash should be 12 chars, got %d", len(hash1))
+	}
+
+	// Same input should produce same hash
+	hash1again := repoHash("https://github.com/user/repo1")
+	if hash1 != hash1again {
+		t.Error("same repo should produce same hash")
+	}
+}
+
+func TestCoordDir(t *testing.T) {
+	dir, err := CoordDir("https://github.com/user/repo")
+	if err != nil {
+		t.Fatalf("CoordDir failed: %v", err)
+	}
+
+	if !filepath.IsAbs(dir) {
+		t.Error("CoordDir should return absolute path")
+	}
+
+	if !contains(dir, ".agentctl") || !contains(dir, "coordination") {
+		t.Errorf("unexpected dir path: %s", dir)
+	}
+}
+
+func TestInit(t *testing.T) {
+	repoURL := "https://github.com/test/init-test-" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Check that all files were created
+	for _, file := range []string{"claims.json", "messages.jsonl", "state.json"} {
+		path := filepath.Join(dir, file)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("Init should create %s", file)
+		}
+	}
+
+	// Init should be idempotent
+	dir2, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("second Init failed: %v", err)
+	}
+	if dir != dir2 {
+		t.Error("Init should return the same directory on second call")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/coordination/state.go
+++ b/pkg/coordination/state.go
@@ -1,0 +1,104 @@
+package coordination
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// AgentState represents the coordination state of a single agent.
+type AgentState struct {
+	Name       string    `json:"name"`
+	Branch     string    `json:"branch,omitempty"`
+	Status     string    `json:"status"` // "working", "idle", "done", "blocked"
+	LastUpdate time.Time `json:"last_update"`
+}
+
+// State represents the shared coordination state for a repo.
+type State struct {
+	Agents      map[string]*AgentState `json:"agents"`
+	LastUpdated string                 `json:"last_updated"`
+}
+
+// UpdateAgentState updates an agent's state in the shared state file.
+func UpdateAgentState(repoURL, agentName, status, branch string) error {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return err
+	}
+
+	state, err := loadState(dir)
+	if err != nil {
+		return err
+	}
+
+	state.Agents[agentName] = &AgentState{
+		Name:       agentName,
+		Branch:     branch,
+		Status:     status,
+		LastUpdate: time.Now(),
+	}
+	state.LastUpdated = time.Now().Format(time.RFC3339)
+
+	return saveState(dir, state)
+}
+
+// RemoveAgentState removes an agent from the shared state.
+func RemoveAgentState(repoURL, agentName string) error {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return err
+	}
+
+	state, err := loadState(dir)
+	if err != nil {
+		return err
+	}
+
+	delete(state.Agents, agentName)
+	state.LastUpdated = time.Now().Format(time.RFC3339)
+
+	return saveState(dir, state)
+}
+
+// GetState returns the current coordination state.
+func GetState(repoURL string) (*State, error) {
+	dir, err := CoordDir(repoURL)
+	if err != nil {
+		return nil, err
+	}
+	return loadState(dir)
+}
+
+func loadState(dir string) (*State, error) {
+	statePath := filepath.Join(dir, "state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &State{Agents: make(map[string]*AgentState)}, nil
+		}
+		return nil, fmt.Errorf("cannot read state.json: %w", err)
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("cannot parse state.json: %w", err)
+	}
+
+	if state.Agents == nil {
+		state.Agents = make(map[string]*AgentState)
+	}
+	return &state, nil
+}
+
+func saveState(dir string, state *State) error {
+	statePath := filepath.Join(dir, "state.json")
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal state: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(statePath, data, 0644)
+}

--- a/pkg/coordination/state_test.go
+++ b/pkg/coordination/state_test.go
@@ -1,0 +1,136 @@
+package coordination
+
+import (
+	"os"
+	"testing"
+)
+
+func TestUpdateAgentState(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := UpdateAgentState(repoURL, "agent-1", "working", "feature-branch"); err != nil {
+		t.Fatalf("UpdateAgentState failed: %v", err)
+	}
+
+	state, err := GetState(repoURL)
+	if err != nil {
+		t.Fatalf("GetState failed: %v", err)
+	}
+
+	if len(state.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(state.Agents))
+	}
+
+	agent := state.Agents["agent-1"]
+	if agent == nil {
+		t.Fatal("agent-1 not found in state")
+	}
+	if agent.Name != "agent-1" {
+		t.Errorf("expected name agent-1, got %s", agent.Name)
+	}
+	if agent.Status != "working" {
+		t.Errorf("expected status working, got %s", agent.Status)
+	}
+	if agent.Branch != "feature-branch" {
+		t.Errorf("expected branch feature-branch, got %s", agent.Branch)
+	}
+	if agent.LastUpdate.IsZero() {
+		t.Error("LastUpdate should be set")
+	}
+}
+
+func TestUpdateAgentStateOverwrite(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	UpdateAgentState(repoURL, "agent-1", "working", "branch-1")
+	UpdateAgentState(repoURL, "agent-1", "done", "branch-1")
+
+	state, _ := GetState(repoURL)
+	if state.Agents["agent-1"].Status != "done" {
+		t.Error("status should be updated to done")
+	}
+}
+
+func TestMultipleAgentStates(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	UpdateAgentState(repoURL, "agent-1", "working", "branch-1")
+	UpdateAgentState(repoURL, "agent-2", "idle", "branch-2")
+
+	state, _ := GetState(repoURL)
+	if len(state.Agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(state.Agents))
+	}
+}
+
+func TestRemoveAgentState(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	UpdateAgentState(repoURL, "agent-1", "working", "branch-1")
+	UpdateAgentState(repoURL, "agent-2", "idle", "branch-2")
+
+	if err := RemoveAgentState(repoURL, "agent-1"); err != nil {
+		t.Fatalf("RemoveAgentState failed: %v", err)
+	}
+
+	state, _ := GetState(repoURL)
+	if len(state.Agents) != 1 {
+		t.Fatalf("expected 1 agent after removal, got %d", len(state.Agents))
+	}
+	if _, ok := state.Agents["agent-1"]; ok {
+		t.Error("agent-1 should have been removed")
+	}
+}
+
+func TestGetStateEmpty(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	state, err := GetState(repoURL)
+	if err != nil {
+		t.Fatalf("GetState failed: %v", err)
+	}
+	if len(state.Agents) != 0 {
+		t.Errorf("expected 0 agents initially, got %d", len(state.Agents))
+	}
+}
+
+func TestStateLastUpdated(t *testing.T) {
+	repoURL := "https://github.com/test/" + t.Name()
+	dir, err := Init(repoURL)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	UpdateAgentState(repoURL, "agent-1", "working", "main")
+
+	state, _ := GetState(repoURL)
+	if state.LastUpdated == "" {
+		t.Error("LastUpdated should be set after update")
+	}
+}


### PR DESCRIPTION
## Summary

Implements agent coordination via a shared file-based message bus, enabling multiple agents working on the same repo to avoid edit conflicts and stay synchronized.

- **Coordination directory** at `~/.agentctl/coordination/<repo-hash>/` with `claims.json`, `messages.jsonl`, and `state.json`
- **File claiming system** — agents claim files before editing; conflicts are rejected with clear error messages
- **Message bus** (JSONL append-only log) with types: `claim`, `release`, `committed`, `pushed`, `pr_created`, `merged`, `rebase_needed`
- **CLI commands**: `agentctl claim`, `agentctl release`, `agentctl notify`, `agentctl bus`
- **Supervisor integration** — `RunUntilDone` loop checks for `rebase_needed` signals and updates agent state (`working`/`done`/`blocked`)

## Test plan

- [x] Code compiles (`go build ./cmd/agentctl/`)
- [x] `go vet ./...` passes
- [x] Claim/release/notify/bus commands tested manually
- [x] Claim conflict detection verified (agent-2 can't claim file held by agent-1)
- [x] Release + re-claim by different agent works
- [ ] Integration test with multiple spawned agents on same repo

Closes #6