### PR TITLE
feat: auto-cleanup completed and stale agent containers

### DIFF
--- a/pkg/container/lifecycle.go
+++ b/pkg/container/lifecycle.go
@@ -1,0 +1,254 @@
+package container
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DefaultGracePeriod is how long a completed agent container stays before auto-cleanup.
+const DefaultGracePeriod = 1 * time.Hour
+
+// AgentHistory preserves metadata about an agent after its container is removed.
+type AgentHistory struct {
+	Name        string            `json:"name"`
+	Repo        string            `json:"repo"`
+	Branch      string            `json:"branch"`
+	Intent      string            `json:"intent,omitempty"`
+	Created     time.Time         `json:"created"`
+	CompletedAt time.Time         `json:"completed_at,omitempty"`
+	RemovedAt   time.Time         `json:"removed_at,omitempty"`
+	Result      string            `json:"result"` // "success", "failed", "killed"
+	Attempts    int               `json:"attempts,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"` // PR URL, commit SHA, etc.
+}
+
+// historyDir returns the path to the agent history directory.
+func historyDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".agentctl", "history")
+}
+
+func historyPath(name string) string {
+	return filepath.Join(historyDir(), name+".json")
+}
+
+// SaveHistory persists an agent history record.
+func SaveHistory(h *AgentHistory) error {
+	if err := os.MkdirAll(historyDir(), 0755); err != nil {
+		return fmt.Errorf("failed to create history dir: %w", err)
+	}
+	data, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal history: %w", err)
+	}
+	return os.WriteFile(historyPath(h.Name), data, 0644)
+}
+
+// LoadHistory loads a single agent history record.
+func LoadHistory(name string) (*AgentHistory, error) {
+	data, err := os.ReadFile(historyPath(name))
+	if err != nil {
+		return nil, fmt.Errorf("history not found: %s", name)
+	}
+	var h AgentHistory
+	if err := json.Unmarshal(data, &h); err != nil {
+		return nil, fmt.Errorf("failed to parse history: %w", err)
+	}
+	return &h, nil
+}
+
+// ListHistory returns all agent history records.
+func ListHistory() ([]*AgentHistory, error) {
+	entries, err := os.ReadDir(historyDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var records []*AgentHistory
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(historyDir(), e.Name()))
+		if err != nil {
+			continue
+		}
+		var h AgentHistory
+		if err := json.Unmarshal(data, &h); err != nil {
+			continue
+		}
+		records = append(records, &h)
+	}
+	return records, nil
+}
+
+// AgentLifecycleState categorizes an agent's current lifecycle phase.
+type AgentLifecycleState string
+
+const (
+	StateActive    AgentLifecycleState = "active"    // Claude is running, work in progress
+	StateCompleted AgentLifecycleState = "completed" // Task done, awaiting cleanup
+	StateExited    AgentLifecycleState = "exited"    // Container exited (may be stale)
+	StateStopped   AgentLifecycleState = "stopped"   // Container not found
+)
+
+// AgentWithState enriches an Agent with lifecycle information.
+type AgentWithState struct {
+	*Agent
+	Lifecycle   AgentLifecycleState `json:"lifecycle"`
+	ContainerUp bool                `json:"container_up"`
+	Age         time.Duration       `json:"-"`
+}
+
+// ListWithState returns all agents enriched with lifecycle state.
+func ListWithState() ([]*AgentWithState, error) {
+	entries, _ := os.ReadDir(agentDir())
+	var agents []*AgentWithState
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, _ := os.ReadFile(filepath.Join(agentDir(), e.Name()))
+		var agent Agent
+		if err := json.Unmarshal(data, &agent); err != nil {
+			continue
+		}
+
+		aws := &AgentWithState{
+			Agent: &agent,
+			Age:   time.Since(agent.Created),
+		}
+
+		// Get container status from podman
+		out, _ := exec.Command("podman", "inspect", "-f", "{{.State.Status}}", agent.Name).Output()
+		containerStatus := strings.TrimSpace(string(out))
+
+		switch containerStatus {
+		case "running":
+			aws.ContainerUp = true
+			// Check if Claude is still working
+			psOut, _ := exec.Command("podman", "exec", agent.Name, "sh", "-c",
+				"ps aux 2>/dev/null | grep -v grep | grep claude || true").Output()
+			if len(strings.TrimSpace(string(psOut))) > 0 {
+				aws.Lifecycle = StateActive
+			} else {
+				aws.Lifecycle = StateCompleted
+			}
+		case "exited":
+			aws.ContainerUp = false
+			aws.Lifecycle = StateExited
+		default:
+			aws.ContainerUp = false
+			aws.Lifecycle = StateStopped
+		}
+
+		agent.Status = containerStatus
+		if agent.Status == "" {
+			agent.Status = "stopped"
+		}
+
+		agents = append(agents, aws)
+	}
+	return agents, nil
+}
+
+// Cleanup stops and removes a single agent container, preserving history.
+func Cleanup(name string, result string, attempts int, metadata map[string]string) error {
+	agent, err := loadAgent(name)
+	if err != nil {
+		return fmt.Errorf("agent not found: %s", name)
+	}
+
+	// Save history before removing
+	h := &AgentHistory{
+		Name:        agent.Name,
+		Repo:        agent.Repo,
+		Branch:      agent.Branch,
+		Intent:      agent.Intent,
+		Created:     agent.Created,
+		CompletedAt: time.Now(),
+		RemovedAt:   time.Now(),
+		Result:      result,
+		Attempts:    attempts,
+		Metadata:    metadata,
+	}
+	if err := SaveHistory(h); err != nil {
+		return fmt.Errorf("failed to save history: %w", err)
+	}
+
+	// Stop and remove container
+	exec.Command("podman", "stop", name).Run()
+	exec.Command("podman", "rm", name).Run()
+
+	// Remove agent metadata file
+	os.Remove(agentMetaPath(name))
+
+	return nil
+}
+
+// Prune removes all exited and stopped agent containers, preserving history.
+func Prune() ([]string, error) {
+	agents, err := ListWithState()
+	if err != nil {
+		return nil, err
+	}
+
+	var pruned []string
+	for _, a := range agents {
+		if a.Lifecycle == StateExited || a.Lifecycle == StateStopped {
+			if err := Cleanup(a.Name, "pruned", 0, nil); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to prune %s: %v\n", a.Name, err)
+				continue
+			}
+			pruned = append(pruned, a.Name)
+		}
+	}
+	return pruned, nil
+}
+
+// CleanupCompleted removes completed agents that have exceeded the grace period.
+func CleanupCompleted(gracePeriod time.Duration) ([]string, error) {
+	agents, err := ListWithState()
+	if err != nil {
+		return nil, err
+	}
+
+	var cleaned []string
+	for _, a := range agents {
+		if a.Lifecycle == StateCompleted && a.Age > gracePeriod {
+			if err := Cleanup(a.Name, "success", 0, nil); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to cleanup %s: %v\n", a.Name, err)
+				continue
+			}
+			cleaned = append(cleaned, a.Name)
+		}
+	}
+	return cleaned, nil
+}
+
+// CleanupStale removes containers that have been exited for longer than the grace period.
+func CleanupStale(gracePeriod time.Duration) ([]string, error) {
+	agents, err := ListWithState()
+	if err != nil {
+		return nil, err
+	}
+
+	var cleaned []string
+	for _, a := range agents {
+		if (a.Lifecycle == StateExited || a.Lifecycle == StateStopped) && a.Age > gracePeriod {
+			if err := Cleanup(a.Name, "stale", 0, nil); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to cleanup %s: %v\n", a.Name, err)
+				continue
+			}
+			cleaned = append(cleaned, a.Name)
+		}
+	}
+	return cleaned, nil
+}

--- a/pkg/container/lifecycle_test.go
+++ b/pkg/container/lifecycle_test.go
@@ -1,0 +1,262 @@
+package container
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHistoryDir(t *testing.T) {
+	dir := historyDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get home dir: %v", err)
+	}
+	expected := filepath.Join(home, ".agentctl", "history")
+	if dir != expected {
+		t.Errorf("historyDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestSaveAndLoadHistory(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	h := &AgentHistory{
+		Name:        "test-agent",
+		Repo:        "https://github.com/test/repo",
+		Branch:      "main",
+		Intent:      "fix tests",
+		Created:     time.Now().Add(-1 * time.Hour),
+		CompletedAt: time.Now(),
+		RemovedAt:   time.Now(),
+		Result:      "success",
+		Attempts:    3,
+		Metadata: map[string]string{
+			"pr_url": "https://github.com/test/repo/pull/1",
+		},
+	}
+
+	err := SaveHistory(h)
+	if err != nil {
+		t.Fatalf("SaveHistory() error: %v", err)
+	}
+
+	loaded, err := LoadHistory("test-agent")
+	if err != nil {
+		t.Fatalf("LoadHistory() error: %v", err)
+	}
+
+	if loaded.Name != h.Name {
+		t.Errorf("Name = %q, want %q", loaded.Name, h.Name)
+	}
+	if loaded.Repo != h.Repo {
+		t.Errorf("Repo = %q, want %q", loaded.Repo, h.Repo)
+	}
+	if loaded.Branch != h.Branch {
+		t.Errorf("Branch = %q, want %q", loaded.Branch, h.Branch)
+	}
+	if loaded.Intent != h.Intent {
+		t.Errorf("Intent = %q, want %q", loaded.Intent, h.Intent)
+	}
+	if loaded.Result != h.Result {
+		t.Errorf("Result = %q, want %q", loaded.Result, h.Result)
+	}
+	if loaded.Attempts != h.Attempts {
+		t.Errorf("Attempts = %d, want %d", loaded.Attempts, h.Attempts)
+	}
+	if loaded.Metadata["pr_url"] != h.Metadata["pr_url"] {
+		t.Errorf("Metadata[pr_url] = %q, want %q", loaded.Metadata["pr_url"], h.Metadata["pr_url"])
+	}
+}
+
+func TestLoadHistoryNotFound(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	_, err := LoadHistory("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent history, got nil")
+	}
+}
+
+func TestListHistory(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	// Empty history should return nil, nil
+	records, err := ListHistory()
+	if err != nil {
+		t.Fatalf("ListHistory() error on empty: %v", err)
+	}
+	if records != nil {
+		t.Errorf("expected nil for empty history, got %d records", len(records))
+	}
+
+	// Save two records
+	h1 := &AgentHistory{Name: "agent-1", Result: "success"}
+	h2 := &AgentHistory{Name: "agent-2", Result: "failed"}
+	SaveHistory(h1)
+	SaveHistory(h2)
+
+	records, err = ListHistory()
+	if err != nil {
+		t.Fatalf("ListHistory() error: %v", err)
+	}
+	if len(records) != 2 {
+		t.Errorf("ListHistory() returned %d records, want 2", len(records))
+	}
+}
+
+func TestSaveHistoryOverwrite(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	h := &AgentHistory{Name: "agent-1", Result: "failed"}
+	SaveHistory(h)
+
+	h.Result = "success"
+	SaveHistory(h)
+
+	loaded, _ := LoadHistory("agent-1")
+	if loaded.Result != "success" {
+		t.Errorf("Result = %q, want %q after overwrite", loaded.Result, "success")
+	}
+}
+
+func TestSaveHistoryWithNilMetadata(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	h := &AgentHistory{Name: "agent-nil-meta", Result: "success", Metadata: nil}
+	err := SaveHistory(h)
+	if err != nil {
+		t.Fatalf("SaveHistory() with nil metadata error: %v", err)
+	}
+
+	loaded, err := LoadHistory("agent-nil-meta")
+	if err != nil {
+		t.Fatalf("LoadHistory() error: %v", err)
+	}
+	if loaded.Name != "agent-nil-meta" {
+		t.Errorf("Name = %q, want %q", loaded.Name, "agent-nil-meta")
+	}
+}
+
+func TestHistoryDirCreation(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	// History dir shouldn't exist yet
+	hDir := filepath.Join(tmpHome, ".agentctl", "history")
+	if _, err := os.Stat(hDir); !os.IsNotExist(err) {
+		t.Fatal("history dir should not exist before SaveHistory")
+	}
+
+	SaveHistory(&AgentHistory{Name: "test"})
+
+	// Now it should exist
+	info, err := os.Stat(hDir)
+	if err != nil {
+		t.Fatalf("history dir should exist after SaveHistory: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("history path should be a directory")
+	}
+}
+
+func TestAgentLifecycleStates(t *testing.T) {
+	// Verify the constants are distinct
+	states := []AgentLifecycleState{StateActive, StateCompleted, StateExited, StateStopped}
+	seen := make(map[AgentLifecycleState]bool)
+	for _, s := range states {
+		if seen[s] {
+			t.Errorf("duplicate lifecycle state: %s", s)
+		}
+		seen[s] = true
+	}
+}
+
+func TestCleanupPreservesHistory(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	// Create an agent metadata file
+	agent := &Agent{
+		Name:        "cleanup-test",
+		ContainerID: "abc123",
+		Port:        8042,
+		Repo:        "https://github.com/test/repo",
+		Branch:      "main",
+		Status:      "exited",
+		Created:     time.Now().Add(-2 * time.Hour),
+	}
+	saveAgent(agent)
+
+	// Verify agent file exists
+	if _, err := loadAgent("cleanup-test"); err != nil {
+		t.Fatalf("agent should exist before cleanup: %v", err)
+	}
+
+	// Cleanup (podman commands will fail silently in test, which is fine)
+	err := Cleanup("cleanup-test", "success", 2, map[string]string{"pr": "https://example.com/pr/1"})
+	if err != nil {
+		t.Fatalf("Cleanup() error: %v", err)
+	}
+
+	// Agent metadata should be gone
+	if _, err := loadAgent("cleanup-test"); err == nil {
+		t.Error("agent metadata should be removed after cleanup")
+	}
+
+	// History should be preserved
+	h, err := LoadHistory("cleanup-test")
+	if err != nil {
+		t.Fatalf("history should exist after cleanup: %v", err)
+	}
+	if h.Result != "success" {
+		t.Errorf("Result = %q, want %q", h.Result, "success")
+	}
+	if h.Attempts != 2 {
+		t.Errorf("Attempts = %d, want %d", h.Attempts, 2)
+	}
+	if h.Metadata["pr"] != "https://example.com/pr/1" {
+		t.Errorf("Metadata[pr] = %q, want %q", h.Metadata["pr"], "https://example.com/pr/1")
+	}
+	if h.Repo != "https://github.com/test/repo" {
+		t.Errorf("Repo = %q, want %q", h.Repo, "https://github.com/test/repo")
+	}
+}
+
+func TestCleanupAgentNotFound(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	err := Cleanup("nonexistent", "killed", 0, nil)
+	if err == nil {
+		t.Error("expected error for nonexistent agent cleanup")
+	}
+}
+
+func TestDefaultGracePeriod(t *testing.T) {
+	if DefaultGracePeriod != 1*time.Hour {
+		t.Errorf("DefaultGracePeriod = %v, want 1h", DefaultGracePeriod)
+	}
+}

--- a/pkg/container/supervisor.go
+++ b/pkg/container/supervisor.go
@@ -106,6 +106,17 @@ Keep going until tests pass and all changes are committed.`,
 				coordination.UpdateAgentState(repoURL, name, "done", "")
 				coordination.ReleaseAllForAgent(repoURL, name)
 			}
+
+			// Save completion history for eventual cleanup
+			SaveHistory(&AgentHistory{
+				Name:        name,
+				Repo:        repoURL,
+				Created:     loopStart,
+				CompletedAt: time.Now(),
+				Result:      "success",
+				Attempts:    attempt,
+			})
+
 			return result, nil
 		}
 


### PR DESCRIPTION
## Summary

- Adds agent lifecycle management with four distinct states: **active** (Claude running), **completed** (task done, awaiting cleanup), **exited** (container stopped), **stopped** (container gone)
- Preserves agent history (task, result, PR URL, attempts) in `~/.agentctl/history/` after container removal
- New `prune` command for immediate cleanup of all exited/stopped containers
- New `cleanup [grace-period]` command removes completed/stale agents past a configurable grace period (default: 1 hour)
- New `history` command shows past agent results even after container removal
- Enhanced `list` output distinguishes lifecycle states with distinct indicators and age display
- Supervisor records completion history automatically when a task finishes successfully

## Test plan

- [x] All 51 existing + new tests pass (`go test ./...`)
- [x] `go vet ./...` passes clean
- [x] `gofmt` reports no formatting issues
- [ ] Manual test: `agentctl prune` removes exited containers
- [ ] Manual test: `agentctl cleanup 30m` respects grace period
- [ ] Manual test: `agentctl history` shows preserved metadata
- [ ] Manual test: `agentctl list` shows lifecycle indicators

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `list` command now displays agent lifecycle status (Active, Completed, Exited, Stopped), truncated container ID, and age
  * New `prune` command to remove exited and stopped containers
  * New `cleanup` command with optional grace period for removing completed agents
  * New `history` command to view records of past agents with completion timestamps and metadata
  * Automatic history persistence for completed agents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->