### PR TITLE
feat: intent tracking, knowledge capture, and systemd cleanup timer

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -20,14 +20,24 @@ func main() {
 	switch os.Args[1] {
 	case "spawn":
 		if len(os.Args) < 4 {
-			fmt.Println("Usage: agentctl spawn <name> <repo> [branch]")
+			fmt.Println("Usage: agentctl spawn <name> <repo> [branch] [--intent <text>]")
 			os.Exit(1)
 		}
 		branch := "main"
-		if len(os.Args) > 4 {
-			branch = os.Args[4]
+		intent := ""
+		positional := 0
+		for i := 4; i < len(os.Args); i++ {
+			if os.Args[i] == "--intent" && i+1 < len(os.Args) {
+				intent = os.Args[i+1]
+				i++ // skip next arg
+			} else if !strings.HasPrefix(os.Args[i], "--") {
+				if positional == 0 {
+					branch = os.Args[i]
+				}
+				positional++
+			}
 		}
-		agent, err := container.Spawn(os.Args[2], os.Args[3], branch)
+		agent, err := container.SpawnWithIntent(os.Args[2], os.Args[3], branch, intent)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)

--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -44,6 +44,19 @@ func ensureCacheDirs() error {
 	return nil
 }
 
+// SpawnWithIntent creates a new agent container with the given repo cloned and an intent description.
+func SpawnWithIntent(name, repo, branch, intent string) (*Agent, error) {
+	agent, err := Spawn(name, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	if intent != "" {
+		agent.Intent = intent
+		saveAgent(agent)
+	}
+	return agent, nil
+}
+
 // Spawn creates a new agent container with the given repo cloned
 func Spawn(name, repo, branch string) (*Agent, error) {
 	rand.Seed(time.Now().UnixNano())

--- a/pkg/container/lifecycle.go
+++ b/pkg/container/lifecycle.go
@@ -183,6 +183,11 @@ func Cleanup(name string, result string, attempts int, metadata map[string]strin
 		return fmt.Errorf("failed to save history: %w", err)
 	}
 
+	// Capture intent in knowledge base before removing
+	if h.Intent != "" {
+		captureIntentKnowledge(h)
+	}
+
 	// Stop and remove container
 	exec.Command("podman", "stop", name).Run()
 	exec.Command("podman", "rm", name).Run()
@@ -191,6 +196,35 @@ func Cleanup(name string, result string, attempts int, metadata map[string]strin
 	os.Remove(agentMetaPath(name))
 
 	return nil
+}
+
+// captureIntentKnowledge feeds agent intent and result into the know CLI for post-mortem tracking.
+func captureIntentKnowledge(h *AgentHistory) {
+	title := fmt.Sprintf("Agent %s: %s", h.Name, h.Result)
+	content := fmt.Sprintf("Intent: %s\nRepo: %s\nBranch: %s\nResult: %s\nDuration: %s",
+		h.Intent, h.Repo, h.Branch, h.Result,
+		h.CompletedAt.Sub(h.Created).Round(time.Minute))
+
+	if h.Metadata != nil {
+		for k, v := range h.Metadata {
+			content += fmt.Sprintf("\n%s: %s", k, v)
+		}
+	}
+
+	args := []string{
+		"add", title,
+		"--content", content,
+		"--category", "deployment",
+		"--tags", "agent,agentctl," + h.Result,
+		"--repo", h.Repo,
+		"--branch", h.Branch,
+		"--confidence", "80",
+		"--no-git",
+		"--skip-enhance",
+		"--force",
+		"-n",
+	}
+	exec.Command("know", args...).Run()
 }
 
 // Prune removes all exited and stopped agent containers, preserving history.


### PR DESCRIPTION
## Summary
- Add `--intent` flag to `agentctl spawn` so dispatchers (prefrontal-cortex) can tag agents with their task description
- On cleanup, agents with intent automatically feed their summary into `know add` for post-mortem knowledge capture
- Systemd user timer (`agentctl-cleanup.timer`) runs `agentctl cleanup 1h` every 30 minutes to prevent orphaned containers (like the gate-44/45/46/47 incident)

## Test plan
- [x] `go test ./...` passes
- [x] Binary builds and installs cleanly
- [x] Systemd timer enabled and active on odin
- [x] Orphaned gate-* containers cleaned successfully
- [ ] Verify `know add` entries appear after cleanup of intent-bearing agents
- [ ] Test `agentctl spawn foo https://github.com/user/repo main --intent "fix tests"` sets intent in metadata

## Notes
- Systemd unit files live in `~/.config/systemd/user/` (not in repo) — this PR only covers the Go code changes
- Prefrontal-cortex dispatch side still needs updating to pass `--intent` when spawning gate-* agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--intent` flag support to specify agent intent during spawn operations
  * Agent execution metadata including intent, repository, branch, results, and execution duration are now automatically captured and stored to a knowledge base upon completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->