### PR TITLE
feat: hot-swap image support via --image flag and run-task entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Install Claude CLI
 RUN npm install -g @anthropic-ai/claude-code
 
+# Standard agentctl run-task entrypoint (claude variant)
+COPY scripts/run-task /usr/local/bin/run-task
+
 # Create agent user
 RUN useradd -m -s /bin/bash agent \
     && mkdir -p /home/agent/workspace \

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -20,16 +20,20 @@ func main() {
 	switch os.Args[1] {
 	case "spawn":
 		if len(os.Args) < 4 {
-			fmt.Println("Usage: agentctl spawn <name> <repo> [branch] [--intent <text>]")
+			fmt.Println("Usage: agentctl spawn <name> <repo> [branch] [--image <image>] [--intent <text>]")
 			os.Exit(1)
 		}
 		branch := "main"
 		intent := ""
+		image := ""
 		positional := 0
 		for i := 4; i < len(os.Args); i++ {
 			if os.Args[i] == "--intent" && i+1 < len(os.Args) {
 				intent = os.Args[i+1]
-				i++ // skip next arg
+				i++
+			} else if os.Args[i] == "--image" && i+1 < len(os.Args) {
+				image = os.Args[i+1]
+				i++
 			} else if !strings.HasPrefix(os.Args[i], "--") {
 				if positional == 0 {
 					branch = os.Args[i]
@@ -37,12 +41,13 @@ func main() {
 				positional++
 			}
 		}
-		agent, err := container.SpawnWithIntent(os.Args[2], os.Args[3], branch, intent)
+		agent, err := container.SpawnWithIntent(os.Args[2], os.Args[3], branch, intent, image)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("🤖 Agent: %s\n📦 Container: %s\n🌐 Port: %d\n", agent.Name, agent.ContainerID[:12], agent.Port)
+		img := agent.Image
+		fmt.Printf("🤖 Agent: %s\n📦 Container: %s\n🖼️  Image: %s\n🌐 Port: %d\n", agent.Name, agent.ContainerID[:12], img, agent.Port)
 
 	case "run":
 		// Run until done: agentctl run <name> <task> [max-attempts]
@@ -517,7 +522,7 @@ func printUsage() {
 	fmt.Println("agentctl - Claude Code Agent Container Orchestrator")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  spawn <name> <repo> [branch]    Create new agent container")
+	fmt.Println("  spawn <name> <repo> [branch] [--image <img>]  Create new agent container")
 	fmt.Println("  run <name> <task> [attempts]    Run until task complete (Ralph Wiggum mode)")
 	fmt.Println("  check <name>                    Check if agent's task is complete")
 	fmt.Println("  list                            List all agents with lifecycle status")
@@ -540,7 +545,7 @@ func printUsage() {
 	fmt.Println("  bus <repo-url> [--claims|--messages|--state] Show coordination bus state")
 	fmt.Println()
 	fmt.Println("Example:")
-	fmt.Println("  agentctl spawn fix-bug https://github.com/user/repo feature-branch")
+	fmt.Println("  agentctl spawn fix-bug https://github.com/user/repo feature-branch --image agent-lexi:latest")
 	fmt.Println("  agentctl run fix-bug 'Fix the failing tests in src/auth.go'")
 	fmt.Println("  agentctl spy fix-bug")
 	fmt.Println("  agentctl check fix-bug")

--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -17,10 +17,13 @@ type Agent struct {
 	Port        int       `json:"port"`
 	Repo        string    `json:"repo"`
 	Branch      string    `json:"branch"`
+	Image       string    `json:"image,omitempty"`
 	Status      string    `json:"status"`
 	Created     time.Time `json:"created"`
 	Intent      string    `json:"intent,omitempty"`
 }
+
+const DefaultImage = "agent-devbox:latest"
 
 // cacheDir returns the path to the shared cache directory on the host
 func cacheDir() string {
@@ -45,8 +48,8 @@ func ensureCacheDirs() error {
 }
 
 // SpawnWithIntent creates a new agent container with the given repo cloned and an intent description.
-func SpawnWithIntent(name, repo, branch, intent string) (*Agent, error) {
-	agent, err := Spawn(name, repo, branch)
+func SpawnWithIntent(name, repo, branch, intent, image string) (*Agent, error) {
+	agent, err := Spawn(name, repo, branch, image)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +61,7 @@ func SpawnWithIntent(name, repo, branch, intent string) (*Agent, error) {
 }
 
 // Spawn creates a new agent container with the given repo cloned
-func Spawn(name, repo, branch string) (*Agent, error) {
+func Spawn(name, repo, branch, image string) (*Agent, error) {
 	rand.Seed(time.Now().UnixNano())
 	port := 8000 + rand.Intn(1000)
 
@@ -76,6 +79,10 @@ func Spawn(name, repo, branch string) (*Agent, error) {
 		}
 	}
 
+	if image == "" {
+		image = DefaultImage
+	}
+
 	cache := cacheDir()
 	args := []string{
 		"run", "-d",
@@ -86,7 +93,7 @@ func Spawn(name, repo, branch string) (*Agent, error) {
 		"-v", fmt.Sprintf("%s/npm:/home/agent/.cache/npm:z", cache),
 		"-v", fmt.Sprintf("%s/go-mod:/home/agent/.cache/go-mod:z", cache),
 		"-v", fmt.Sprintf("%s/pip:/home/agent/.cache/pip:z", cache),
-		"agent-devbox:latest",
+		image,
 	}
 
 	cmd := exec.Command("podman", args...)
@@ -129,6 +136,7 @@ func Spawn(name, repo, branch string) (*Agent, error) {
 		Port:        port,
 		Repo:        repo,
 		Branch:      branch,
+		Image:       image,
 		Status:      "running",
 		Created:     time.Now(),
 	}

--- a/pkg/container/supervisor.go
+++ b/pkg/container/supervisor.go
@@ -79,11 +79,11 @@ Keep going until tests pass and all changes are committed.`,
 				status.TestStatus, status.HasUncommitted, task)
 		}
 
-		// Run Claude
-		fmt.Printf("🤖 Running Claude...\n")
-		err := runClaude(name, prompt)
+		// Run agent via the image's run-task entrypoint
+		fmt.Printf("🤖 Running agent...\n")
+		err := runTask(name, prompt)
 		if err != nil {
-			fmt.Printf("⚠️  Claude error: %v\n", err)
+			fmt.Printf("⚠️  Agent error: %v\n", err)
 		}
 
 		// Wait a moment for things to settle
@@ -191,20 +191,21 @@ func getStatus(name string) AgentStatus {
 		break
 	}
 
-	// Check if Claude is running
+	// Check if the agent task runner is active
 	out, _ = exec.Command("podman", "exec", name, "sh", "-c",
-		"ps aux 2>/dev/null | grep -v grep | grep claude || true").Output()
+		"ps aux 2>/dev/null | grep -v grep | grep -E 'run-task|claude|opencode' || true").Output()
 	status.ClaudeRunning = len(strings.TrimSpace(string(out))) > 0
 
 	return status
 }
 
-func runClaude(name string, prompt string) error {
-	// Escape the prompt for shell
+// runTask calls the image's standard run-task entrypoint with the given prompt.
+// Each image ships its own /usr/local/bin/run-task so agentctl stays image-agnostic.
+func runTask(name string, prompt string) error {
 	escaped := strings.ReplaceAll(prompt, "'", "'\\''")
 
 	cmd := exec.Command("podman", "exec", name, "sh", "-c",
-		fmt.Sprintf("cd /home/agent/workspace/repo && claude --dangerously-skip-permissions -p '%s' 2>&1 | tee -a /home/agent/claude.log", escaped))
+		fmt.Sprintf("cd /home/agent/workspace/repo && run-task '%s' 2>&1 | tee -a /home/agent/claude.log", escaped))
 
 	output, err := cmd.CombinedOutput()
 	if len(output) > 500 {

--- a/scripts/run-task
+++ b/scripts/run-task
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec claude --dangerously-skip-permissions -p "$@"


### PR DESCRIPTION
## Summary

- Adds `--image` flag to `agentctl spawn` — defaults to `agent-devbox:latest`, accepts any image name
- Replaces hardcoded `claude` invocation with a standard `run-task` entrypoint contract
- Each image ships its own `/usr/local/bin/run-task` so agentctl stays image-agnostic
- `agent-devbox` → `run-task` calls Claude Code CLI
- opencode images → `run-task` calls `opencode run`
- Future images just need a `run-task` script

## Usage

```bash
# default (Claude Code)
agentctl spawn my-agent https://github.com/org/repo master

# opencode variant
agentctl spawn my-agent https://github.com/org/repo master --image agent-lexi:latest

# any image
agentctl spawn my-agent https://github.com/org/repo master --image agent-laravel:latest
```

## Files changed

- `pkg/container/agent.go` — `Image` field, `DefaultImage` constant, updated signatures
- `pkg/container/supervisor.go` — `runTask()` calls `run-task` entrypoint, process detection covers claude/opencode
- `cmd/agentctl/main.go` — `--image` flag parsed and shown in spawn output
- `Dockerfile` — `COPY scripts/run-task` into image
- `scripts/run-task` — claude variant entrypoint for `agent-devbox`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify a container image when spawning agents using the optional `--image` flag in the spawn command.
  * Agent metadata is now updated to track the selected container image.

* **Improvements**
  * Enhanced agent execution mechanism to support configurable container images with a default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->