### PR TITLE
feat: agentctl watch command + rebuild agent-devbox with run-task

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -193,6 +193,13 @@ func main() {
 			os.Exit(1)
 		}
 
+	case "watch":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: agentctl watch <name>")
+			os.Exit(1)
+		}
+		watchAgent(os.Args[2])
+
 	case "shell":
 		if len(os.Args) < 3 {
 			fmt.Println("Usage: agentctl shell <name>")
@@ -505,6 +512,46 @@ func main() {
 	}
 }
 
+func watchAgent(name string) {
+	for {
+		fmt.Print("\033[2J\033[H")
+		fmt.Printf("👁️  Watching: %s  —  %s  (Ctrl+C to stop)\n", name, time.Now().Format("15:04:05"))
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+		status := container.CheckCompletion(name)
+
+		testIcon := "❓"
+		switch status.TestStatus {
+		case "pass":
+			testIcon = "✅"
+		case "fail":
+			testIcon = "❌"
+		}
+
+		uncommittedIcon := "✅"
+		if status.HasUncommitted {
+			uncommittedIcon = "⚠️ "
+		}
+
+		agentIcon := "💤"
+		if status.ClaudeRunning {
+			agentIcon = "🤖"
+		}
+
+		fmt.Printf("\n  Tests:        %s %s\n", testIcon, status.TestStatus)
+		fmt.Printf("  Uncommitted:  %s %v\n", uncommittedIcon, status.HasUncommitted)
+		fmt.Printf("  Agent:        %s running=%v\n\n", agentIcon, status.ClaudeRunning)
+
+		if status.TestStatus == "pass" && !status.HasUncommitted {
+			fmt.Println("  ✅ Task complete!")
+		} else {
+			fmt.Println("  ⏳ Working...")
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
 func formatDuration(d time.Duration) string {
 	if d < time.Minute {
 		return fmt.Sprintf("%ds", int(d.Seconds()))
@@ -528,6 +575,7 @@ func printUsage() {
 	fmt.Println("  list                            List all agents with lifecycle status")
 	fmt.Println("  status <name>                   Show agent details")
 	fmt.Println("  logs [-f] <name>                Show Claude logs (-f to follow in real-time)")
+	fmt.Println("  watch <name>                    Poll agent status every 5s (tests/uncommitted/running)")
 	fmt.Println("  spy <name> [flags]              Stream Claude's real-time session activity")
 	fmt.Println("  shell <name>                    Open shell in agent container")
 	fmt.Println("  diagnose <name>                 Debug stuck agents (processes, logs, auth)")


### PR DESCRIPTION
## Summary

- `agentctl watch <name>` — polls agent status every 5s, clears and redraws: tests pass/fail, uncommitted changes, agent running state. Ctrl+C to stop.
- Rebuilt `agent-devbox:latest` locally with `run-task` entrypoint (COPY in Dockerfile)
- Added `watch` to usage/help output

## Usage

```
agentctl watch lexi-346
```

Output refreshes every 5s:
```
👁️  Watching: lexi-346  —  19:23:05  (Ctrl+C to stop)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  Tests:        ✅ pass
  Uncommitted:  ✅ false
  Agent:        🤖 running=true

  ⏳ Working...
```