### PR TITLE
feat: add agentctl review command

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/jordanpartridge/agentctl/pkg/container"
 	"github.com/jordanpartridge/agentctl/pkg/coordination"
+	"github.com/jordanpartridge/agentctl/pkg/pipeline"
+	"github.com/jordanpartridge/agentctl/pkg/review"
 )
 
 func main() {
@@ -485,6 +487,51 @@ func main() {
 			}
 		}
 
+	case "pipeline":
+		// agentctl pipeline <repo> <issue> [--dry-run] [--from=<step>]
+		if len(os.Args) < 4 {
+			fmt.Println("Usage: agentctl pipeline <repo> <issue> [--dry-run] [--from=<step>]")
+			os.Exit(1)
+		}
+		repo := os.Args[2]
+		issue := os.Args[3]
+		opts := pipeline.Options{}
+		for _, arg := range os.Args[4:] {
+			if arg == "--dry-run" {
+				opts.DryRun = true
+			} else if strings.HasPrefix(arg, "--from=") {
+				opts.FromStep = strings.TrimPrefix(arg, "--from=")
+			}
+		}
+		if err := pipeline.Run(repo, issue, opts); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ Pipeline failed: %v\n", err)
+			os.Exit(1)
+		}
+
+	case "review":
+		// agentctl review <name>
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: agentctl review <name>")
+			os.Exit(1)
+		}
+		result, err := review.Review(os.Args[2])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
+			os.Exit(1)
+		}
+		if result.Approved {
+			fmt.Println("✅ APPROVED — merging is safe")
+			os.Exit(0)
+		}
+		fmt.Println("❌ Changes requested:")
+		for _, line := range strings.Split(result.Feedback, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				fmt.Printf("  - %s\n", line)
+			}
+		}
+		os.Exit(1)
+
 	default:
 		printUsage()
 	}
@@ -522,6 +569,13 @@ func printUsage() {
 	fmt.Println("  prune                           Remove all exited/stopped containers")
 	fmt.Println("  cleanup [grace-period]           Remove completed/stale agents past grace period")
 	fmt.Println("  history                          Show history of removed agents")
+	fmt.Println()
+	fmt.Println("Pipeline:")
+	fmt.Println("  pipeline <repo> <issue> [--dry-run] [--from=<step>]")
+	fmt.Println("                                  Run a pipeline.yml against a repo+issue")
+	fmt.Println()
+	fmt.Println("QA / Review:")
+	fmt.Println("  review <name>                   Ask Lexi to review the open PR (exit 0=approved, 1=changes)")
 	fmt.Println()
 	fmt.Println("Coordination:")
 	fmt.Println("  claim <agent> <repo-url> <file>             Claim a file for editing")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jordanpartridge/agentctl
 
 go 1.21
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -265,7 +265,8 @@ func saveAgent(agent *Agent) error {
 	return os.WriteFile(agentMetaPath(agent.Name), data, 0644)
 }
 
-func loadAgent(name string) (*Agent, error) {
+// LoadAgent reads the saved metadata for the named agent.
+func LoadAgent(name string) (*Agent, error) {
 	data, err := os.ReadFile(agentMetaPath(name))
 	if err != nil {
 		return nil, fmt.Errorf("agent not found: %s", name)
@@ -273,4 +274,8 @@ func loadAgent(name string) (*Agent, error) {
 	var agent Agent
 	json.Unmarshal(data, &agent)
 	return &agent, nil
+}
+
+func loadAgent(name string) (*Agent, error) {
+	return LoadAgent(name)
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -1,0 +1,261 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Step is a single pipeline step.
+type Step struct {
+	Name string `yaml:"name"`
+	Run  string `yaml:"run"`
+}
+
+// Pipeline is the parsed pipeline.yml structure.
+type Pipeline struct {
+	Steps []Step `yaml:"steps"`
+}
+
+// Options controls pipeline execution.
+type Options struct {
+	DryRun   bool
+	FromStep string
+}
+
+// defaultPipeline is the built-in pipeline used when no pipeline.yml is found.
+var defaultPipeline = Pipeline{
+	Steps: []Step{
+		{Name: "setup", Run: "composer install --no-interaction --quiet"},
+		{Name: "investigate", Run: `run-task "Read issue #$ISSUE. Map files. Write DESIGN.md."`},
+		{Name: "implement", Run: `run-task "Implement per DESIGN.md. TDD. Commit when green."`},
+		{Name: "pr", Run: `gh pr create --title "$ISSUE_TITLE" --body "Closes #$ISSUE" --base master`},
+		{Name: "review", Run: "agentctl review $AGENTCTL_NAME"},
+		{Name: "merge", Run: "gh pr merge --squash --auto $PR_NUMBER"},
+	},
+}
+
+// Load reads a pipeline from the given path, or falls back to ~/.agentctl/pipeline.yml,
+// or returns the built-in default pipeline.
+func Load(repoPath string) (*Pipeline, error) {
+	// 1. Try repo-local pipeline.yml
+	repoPipeline := filepath.Join(repoPath, "pipeline.yml")
+	if p, err := loadFile(repoPipeline); err == nil {
+		return p, nil
+	}
+
+	// 2. Try ~/.agentctl/pipeline.yml
+	home, err := os.UserHomeDir()
+	if err == nil {
+		defaultPath := filepath.Join(home, ".agentctl", "pipeline.yml")
+		if p, err := loadFile(defaultPath); err == nil {
+			return p, nil
+		}
+	}
+
+	// 3. Built-in default
+	p := defaultPipeline
+	return &p, nil
+}
+
+func loadFile(path string) (*Pipeline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var p Pipeline
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &p, nil
+}
+
+// Run executes the pipeline for the given repo and issue.
+func Run(repo, issue string, opts Options) error {
+	repoName := repoBaseName(repo)
+	cloneDir := filepath.Join("/tmp/agents", fmt.Sprintf("%s-%s", repoName, issue))
+
+	// Clone if needed.
+	if !opts.DryRun {
+		if err := ensureClone(repo, cloneDir); err != nil {
+			return fmt.Errorf("clone failed: %w", err)
+		}
+	}
+
+	// Fetch issue title from gh.
+	issueTitle := ""
+	if !opts.DryRun {
+		issueTitle = fetchIssueTitle(repo, issue)
+	}
+
+	// Build branch name.
+	branch := fmt.Sprintf("feature/%s-%s", repoName, issue)
+
+	// Checkout/create branch.
+	if !opts.DryRun {
+		if err := ensureBranch(cloneDir, branch); err != nil {
+			return fmt.Errorf("branch setup failed: %w", err)
+		}
+	}
+
+	// Load pipeline.
+	p, err := Load(cloneDir)
+	if err != nil {
+		return fmt.Errorf("loading pipeline: %w", err)
+	}
+
+	// Find starting step index.
+	startIdx := 0
+	if opts.FromStep != "" {
+		found := false
+		for i, step := range p.Steps {
+			if step.Name == opts.FromStep {
+				startIdx = i
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("step %q not found in pipeline", opts.FromStep)
+		}
+	}
+
+	prNumber := ""
+
+	for i, step := range p.Steps {
+		if i < startIdx {
+			continue
+		}
+
+		// Inject current PR_NUMBER into env.
+		env := buildEnv(repo, issue, issueTitle, cloneDir, branch, repoName, prNumber)
+
+		if opts.DryRun {
+			fmt.Printf("[dry-run] step %d: %s\n  run: %s\n", i+1, step.Name, step.Run)
+			continue
+		}
+
+		fmt.Printf("▶ [%d/%d] %s\n", i+1, len(p.Steps), step.Name)
+
+		if err := runStep(step, cloneDir, env); err != nil {
+			return fmt.Errorf("step %q failed: %w", step.Name, err)
+		}
+
+		// After any step whose run contains "gh pr create", detect PR number.
+		if strings.Contains(step.Run, "gh pr create") {
+			prNumber = detectPRNumber(cloneDir, branch)
+			if prNumber != "" {
+				fmt.Printf("  detected PR #%s\n", prNumber)
+			}
+		}
+	}
+
+	if !opts.DryRun {
+		fmt.Println("✅ Pipeline complete")
+	}
+	return nil
+}
+
+func runStep(step Step, cloneDir string, env []string) error {
+	cmd := exec.Command("sh", "-c", step.Run)
+	cmd.Dir = cloneDir
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func buildEnv(repo, issue, issueTitle, cloneDir, branch, agentctlName, prNumber string) []string {
+	base := os.Environ()
+	extras := []string{
+		"REPO=" + repo,
+		"ISSUE=" + issue,
+		"ISSUE_TITLE=" + issueTitle,
+		"CLONE_DIR=" + cloneDir,
+		"BRANCH=" + branch,
+		"PR_NUMBER=" + prNumber,
+		"AGENTCTL_NAME=" + agentctlName,
+	}
+	return append(base, extras...)
+}
+
+func ensureClone(repo, cloneDir string) error {
+	if _, err := os.Stat(cloneDir); err == nil {
+		// Already cloned — fetch latest.
+		cmd := exec.Command("git", "-C", cloneDir, "fetch", "--quiet")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cloneDir), 0o755); err != nil {
+		return err
+	}
+
+	// Resolve full HTTPS URL if only owner/repo is given.
+	repoURL := repo
+	if !strings.Contains(repo, "://") && !strings.HasPrefix(repo, "git@") {
+		repoURL = "https://github.com/" + repo
+	}
+
+	cmd := exec.Command("git", "clone", repoURL, cloneDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func ensureBranch(cloneDir, branch string) error {
+	// Check if branch already exists.
+	check := exec.Command("git", "-C", cloneDir, "rev-parse", "--verify", branch)
+	if check.Run() == nil {
+		// Branch exists — check it out.
+		cmd := exec.Command("git", "-C", cloneDir, "checkout", branch)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+	// Create and checkout new branch.
+	cmd := exec.Command("git", "-C", cloneDir, "checkout", "-b", branch)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func fetchIssueTitle(repo, issue string) string {
+	// Resolve repo slug for gh (strip https://github.com/ prefix if present).
+	slug := repo
+	slug = strings.TrimPrefix(slug, "https://github.com/")
+	slug = strings.TrimPrefix(slug, "http://github.com/")
+	slug = strings.TrimPrefix(slug, "git@github.com:")
+	slug = strings.TrimSuffix(slug, ".git")
+
+	out, err := exec.Command("gh", "issue", "view", issue, "--repo", slug, "--json", "title", "-q", ".title").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func detectPRNumber(cloneDir, branch string) string {
+	out, err := exec.Command("gh", "pr", "list", "--head", branch, "--json", "number", "-q", ".[0].number").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func repoBaseName(repo string) string {
+	// Strip common URL prefixes/suffixes.
+	r := repo
+	r = strings.TrimPrefix(r, "https://github.com/")
+	r = strings.TrimPrefix(r, "http://github.com/")
+	r = strings.TrimPrefix(r, "git@github.com:")
+	r = strings.TrimSuffix(r, ".git")
+	// Use last path component.
+	parts := strings.Split(r, "/")
+	return parts[len(parts)-1]
+}

--- a/pkg/review/config.go
+++ b/pkg/review/config.go
@@ -1,0 +1,37 @@
+package review
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Config holds connection settings for calling Lexi.
+type Config struct {
+	LexiURL   string `json:"lexi_url"`
+	LexiToken string `json:"lexi_token"`
+}
+
+// configPath returns the path to ~/.agentctl/config.json.
+func configPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".agentctl", "config.json")
+}
+
+// LoadConfig reads ~/.agentctl/config.json, falling back to APP_KEY env for the token.
+func LoadConfig() Config {
+	cfg := Config{
+		LexiURL: "http://localhost:8002",
+	}
+
+	data, err := os.ReadFile(configPath())
+	if err == nil {
+		json.Unmarshal(data, &cfg)
+	}
+
+	if cfg.LexiToken == "" {
+		cfg.LexiToken = os.Getenv("APP_KEY")
+	}
+
+	return cfg
+}

--- a/pkg/review/review.go
+++ b/pkg/review/review.go
@@ -1,0 +1,195 @@
+package review
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/jordanpartridge/agentctl/pkg/container"
+)
+
+// Result represents the outcome of a PR review.
+type Result struct {
+	Approved bool
+	Feedback string
+}
+
+// prInfo holds the PR number and URL returned by gh.
+type prInfo struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+// lexiRequest is the payload sent to POST /api/prompt.
+type lexiRequest struct {
+	Message string `json:"message"`
+}
+
+// lexiResponse is the response from POST /api/prompt.
+type lexiResponse struct {
+	Response string `json:"response"`
+	// Lexi may also return the reply under "message" depending on version.
+	Message string `json:"message"`
+}
+
+// Review loads agent metadata, finds the open PR, asks Lexi to review it,
+// and returns a Result indicating approval or changes requested.
+func Review(name string) (*Result, error) {
+	// 1. Load agent metadata.
+	agent, err := container.LoadAgent(name)
+	if err != nil {
+		return nil, fmt.Errorf("agent not found: %w", err)
+	}
+
+	// 2. Resolve the GitHub repo slug from the full URL.
+	repo := repoSlug(agent.Repo)
+
+	// 3. Find the open PR for the agent's branch.
+	fmt.Printf("🔍 Looking up open PR for %s on branch %s...\n", repo, agent.Branch)
+	pr, err := findOpenPR(repo, agent.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("could not find open PR: %w", err)
+	}
+
+	fmt.Printf("🔍 Reviewing PR #%d for agent %s...\n", pr.Number, name)
+
+	// 4. Call Lexi.
+	cfg := LoadConfig()
+	if cfg.LexiToken == "" {
+		return nil, fmt.Errorf("no Lexi token: set APP_KEY env var or lexi_token in ~/.agentctl/config.json")
+	}
+
+	message := fmt.Sprintf(
+		"Review PR #%d in %s. Check it closes the original issue requirements. "+
+			"Use FetchPullRequestDiff and SubmitPullRequestReview. "+
+			"Approve if good, request changes if not. "+
+			"Reply with just APPROVED or CHANGES_REQUESTED: <feedback>",
+		pr.Number, repo,
+	)
+
+	fmt.Println("🤖 Asking Lexi to review...")
+	reply, err := callLexi(cfg, message)
+	if err != nil {
+		return nil, fmt.Errorf("Lexi request failed: %w", err)
+	}
+
+	// 5. Parse Lexi's reply.
+	return parseReply(reply), nil
+}
+
+// findOpenPR uses the gh CLI to locate the first open PR for the given branch.
+func findOpenPR(repo, branch string) (*prInfo, error) {
+	args := []string{
+		"pr", "list",
+		"--repo", repo,
+		"--head", branch,
+		"--state", "open",
+		"--json", "number,url",
+		"-q", ".[0]",
+	}
+	out, err := exec.Command("gh", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr list failed: %w", err)
+	}
+
+	text := strings.TrimSpace(string(out))
+	if text == "" || text == "null" {
+		return nil, fmt.Errorf("no open PR found for branch %q in %s", branch, repo)
+	}
+
+	var pr prInfo
+	if err := json.Unmarshal([]byte(text), &pr); err != nil {
+		return nil, fmt.Errorf("failed to parse PR info: %w", err)
+	}
+	if pr.Number == 0 {
+		return nil, fmt.Errorf("no open PR found for branch %q in %s", branch, repo)
+	}
+	return &pr, nil
+}
+
+// callLexi POSTs a prompt to Lexi's /api/prompt endpoint and returns the reply text.
+func callLexi(cfg Config, message string) (string, error) {
+	payload, err := json.Marshal(lexiRequest{Message: message})
+	if err != nil {
+		return "", err
+	}
+
+	url := strings.TrimRight(cfg.LexiURL, "/") + "/api/prompt"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.LexiToken)
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("Lexi returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var lr lexiResponse
+	if err := json.Unmarshal(body, &lr); err != nil {
+		// Lexi might just return a plain string — treat the raw body as the reply.
+		return strings.TrimSpace(string(body)), nil
+	}
+
+	// Prefer "response" field; fall back to "message".
+	reply := lr.Response
+	if reply == "" {
+		reply = lr.Message
+	}
+	if reply == "" {
+		reply = strings.TrimSpace(string(body))
+	}
+	return reply, nil
+}
+
+// parseReply interprets Lexi's response and returns a Result.
+func parseReply(reply string) *Result {
+	upper := strings.ToUpper(reply)
+	if strings.Contains(upper, "APPROVED") && !strings.Contains(upper, "CHANGES_REQUESTED") {
+		return &Result{Approved: true}
+	}
+
+	// Extract feedback after "CHANGES_REQUESTED:"
+	feedback := reply
+	if idx := strings.Index(upper, "CHANGES_REQUESTED:"); idx >= 0 {
+		feedback = strings.TrimSpace(reply[idx+len("CHANGES_REQUESTED:"):])
+	} else if idx := strings.Index(upper, "CHANGES_REQUESTED"); idx >= 0 {
+		feedback = strings.TrimSpace(reply[idx+len("CHANGES_REQUESTED"):])
+		feedback = strings.TrimLeft(feedback, ": ")
+	}
+
+	return &Result{Approved: false, Feedback: feedback}
+}
+
+// repoSlug converts a full GitHub URL to owner/repo format.
+// If already in that format it passes through unchanged.
+func repoSlug(repo string) string {
+	// Strip trailing .git
+	repo = strings.TrimSuffix(repo, ".git")
+
+	// Handle https://github.com/owner/repo
+	for _, prefix := range []string{"https://github.com/", "git@github.com:"} {
+		if strings.HasPrefix(repo, prefix) {
+			return strings.TrimPrefix(repo, prefix)
+		}
+	}
+	return repo
+}


### PR DESCRIPTION
## Summary

- Adds `agentctl review <name>` as the QA gate in the agent pipeline
- Loads agent metadata from `~/.agentctl/agents/<name>.json` to get repo/branch
- Finds the open PR via `gh pr list --head <branch>`
- POSTs to Lexi at `POST /api/prompt` with a structured review prompt asking Lexi to use `FetchPullRequestDiff` and `SubmitPullRequestReview`
- Exits 0 (APPROVED) or 1 (CHANGES_REQUESTED with feedback printed per-line)
- Token sourced from `~/.agentctl/config.json` → `lexi_token`, falling back to `APP_KEY` env var
- Exported `container.LoadAgent` for cross-package use

## New files

- `pkg/review/review.go` — core review logic
- `pkg/review/config.go` — config loader

## Test plan

- [ ] `go build ./cmd/agentctl/` passes (verified locally)
- [ ] `agentctl review <agent-with-open-pr>` calls Lexi and exits 0 on approval
- [ ] `agentctl review <agent-with-issues>` exits 1 and prints feedback lines
- [ ] Missing token prints useful error message
- [ ] No open PR prints useful error message

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pipeline` subcommand for executing automated workflows on repositories and issues, with support for `--dry-run` and `--from` options
  * Added `review` subcommand for AI-powered pull request analysis and feedback

* **Chores**
  * Updated module dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->