### PR TITLE
fix: check GITHUB_TOKEN when GH_TOKEN is unset

### DIFF
--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -70,8 +70,11 @@ func Spawn(name, repo, branch, image string) (*Agent, error) {
 		return nil, fmt.Errorf("cache setup failed: %w", err)
 	}
 
-	// Get GitHub token from environment or gh CLI
+	// Get GitHub token — check both common names then fall back to gh CLI
 	ghToken := os.Getenv("GH_TOKEN")
+	if ghToken == "" {
+		ghToken = os.Getenv("GITHUB_TOKEN")
+	}
 	if ghToken == "" {
 		out, err := exec.Command("gh", "auth", "token").Output()
 		if err == nil {


### PR DESCRIPTION
Lexi's .env uses GITHUB_TOKEN but agentctl only read GH_TOKEN, leaving spawned containers with no auth. Now checks GH_TOKEN → GITHUB_TOKEN → gh auth token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub token sourcing to prioritize standard environment variables (`GH_TOKEN` and `GITHUB_TOKEN`) before falling back to alternative authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->