### PR TITLE
feat: switch run-task to opencode/big-pickle by default

### DIFF
--- a/scripts/run-task
+++ b/scripts/run-task
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec claude --dangerously-skip-permissions -p "$@"
+exec opencode run -m opencode/big-pickle -p "$@"


### PR DESCRIPTION
Swap claude for opencode/big-pickle in run-task. No model token needed. Override still possible by passing -m flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated task execution to use a different underlying tool for script operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->