### PR TITLE
feat: route agent containers through mesh LLM router

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,20 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Claude CLI
-RUN npm install -g @anthropic-ai/claude-code
+# Install Claude CLI (kept for optional use) and opencode (the run-task harness)
+RUN npm install -g @anthropic-ai/claude-code opencode-ai
 
-# Standard agentctl run-task entrypoint (claude CLI via mesh LLM router)
+# Worker tooling: shell linting, JSON wrangling, GitHub CLI
+RUN apt-get update && apt-get install -y shellcheck jq \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Standard agentctl run-task entrypoint (opencode via mesh LLM router)
 COPY scripts/run-task /usr/local/bin/run-task
+# opencode provider config: mesh router, key from AGENT_LLM_KEY env (no baked secrets)
+COPY scripts/opencode.json /opencode-config/opencode.json
 
 # Create agent user
 RUN useradd -m -s /bin/bash agent \
@@ -59,6 +68,13 @@ RUN mkdir -p /home/agent/.cache/go-mod
 
 # pip: initialize cache directory
 RUN mkdir -p /home/agent/.cache/pip
+
+# opencode: provider config + pre-installed SDK deps (runtime npm fetch inside
+# workers is flaky and polluted the shared cache once already)
+RUN mkdir -p /home/agent/.config/opencode \
+    && cp /opencode-config/opencode.json /home/agent/.config/opencode/opencode.json \
+    && cd /home/agent/.config/opencode \
+    && npm install @ai-sdk/openai-compatible @opencode-ai/plugin
 
 # Set environment variables for cache directories
 ENV COMPOSER_CACHE_DIR="/home/agent/.cache/composer"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Install Claude CLI
 RUN npm install -g @anthropic-ai/claude-code
 
-# Standard agentctl run-task entrypoint (claude variant)
+# Standard agentctl run-task entrypoint (claude CLI via mesh LLM router)
 COPY scripts/run-task /usr/local/bin/run-task
 
 # Create agent user

--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -143,19 +143,9 @@ func Spawn(name, repo, branch, image string) (*Agent, error) {
 	containerID := strings.TrimSpace(string(out))
 	time.Sleep(2 * time.Second)
 
-	// Copy Claude auth config from host
-	home, _ := os.UserHomeDir()
-	claudeJSON := filepath.Join(home, ".claude.json")
-	claudeDir := filepath.Join(home, ".claude")
-
-	if _, err := os.Stat(claudeJSON); err == nil {
-		exec.Command("podman", "cp", claudeJSON, name+":/home/agent/.claude.json").Run()
-		exec.Command("podman", "exec", name, "chown", "agent:agent", "/home/agent/.claude.json").Run()
-	}
-	if _, err := os.Stat(claudeDir); err == nil {
-		exec.Command("podman", "cp", claudeDir, name+":/home/agent/.claude").Run()
-		exec.Command("podman", "exec", name, "chown", "-R", "agent:agent", "/home/agent/.claude").Run()
-	}
+	// No Claude config is copied in: the CLI authenticates to the mesh router
+	// via AGENT_LLM_KEY, and copying host ~/.claude would leak session
+	// transcripts and fire host hooks inside the container.
 
 	// Clone the repository if provided
 	if repo != "" {

--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -60,6 +60,29 @@ func SpawnWithIntent(name, repo, branch, intent, image string) (*Agent, error) {
 	return agent, nil
 }
 
+// resolveLLMKey returns the mesh LLM router key for containers: AGENT_LLM_KEY
+// env first, then llm_key in ~/.agentctl/config.json.
+func resolveLLMKey() string {
+	if key := os.Getenv("AGENT_LLM_KEY"); key != "" {
+		return key
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".agentctl", "config.json"))
+	if err != nil {
+		return ""
+	}
+	var cfg struct {
+		LLMKey string `json:"llm_key"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return ""
+	}
+	return cfg.LLMKey
+}
+
 // Spawn creates a new agent container with the given repo cloned
 func Spawn(name, repo, branch, image string) (*Agent, error) {
 	rand.Seed(time.Now().UnixNano())
@@ -92,12 +115,24 @@ func Spawn(name, repo, branch, image string) (*Agent, error) {
 		"--name", name,
 		"-p", fmt.Sprintf("%d:8080", port),
 		"-e", fmt.Sprintf("GH_TOKEN=%s", ghToken),
+	}
+	// LLM router credentials + overrides for the image's run-task.
+	// The key never lives in the image: host env wins, then ~/.agentctl/config.json llm_key.
+	if llmKey := resolveLLMKey(); llmKey != "" {
+		args = append(args, "-e", fmt.Sprintf("AGENT_LLM_KEY=%s", llmKey))
+	}
+	for _, key := range []string{"AGENT_LLM_BASE_URL", "AGENT_LLM_MODEL", "AGENT_LLM_FAST_MODEL"} {
+		if v := os.Getenv(key); v != "" {
+			args = append(args, "-e", fmt.Sprintf("%s=%s", key, v))
+		}
+	}
+	args = append(args,
 		"-v", fmt.Sprintf("%s/composer:/home/agent/.cache/composer:z", cache),
 		"-v", fmt.Sprintf("%s/npm:/home/agent/.cache/npm:z", cache),
 		"-v", fmt.Sprintf("%s/go-mod:/home/agent/.cache/go-mod:z", cache),
 		"-v", fmt.Sprintf("%s/pip:/home/agent/.cache/pip:z", cache),
 		image,
-	}
+	)
 
 	cmd := exec.Command("podman", args...)
 	out, err := cmd.Output()

--- a/scripts/opencode.json
+++ b/scripts/opencode.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "router": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Mesh Router",
+      "options": {
+        "baseURL": "http://host.containers.internal:8101/v1",
+        "apiKey": "{env:AGENT_LLM_KEY}"
+      },
+      "models": {
+        "local-agent": { "name": "qwen3:8b (Loki, agentic)" },
+        "local-code": { "name": "qwen2.5-coder 7b (Loki, codegen)" },
+        "local-fast": { "name": "llama3.1:8b (Loki)" },
+        "cloud-cheap": { "name": "gpt-oss-20b (OpenRouter)" },
+        "cloud-smart": { "name": "grok-4.3 (OpenRouter)" }
+      }
+    }
+  }
+}

--- a/scripts/run-task
+++ b/scripts/run-task
@@ -1,2 +1,15 @@
 #!/bin/sh
-exec opencode run -m opencode/big-pickle -p "$@"
+# Route the agent's Claude CLI through the mesh LLM router (LiteLLM on Odin :8101).
+# Default model: local-code (qwen2.5-coder on Loki GPU); router falls back to cloud-cheap.
+# AGENT_LLM_KEY is injected by agentctl spawn (host env or ~/.agentctl/config.json llm_key)
+# — never baked into the image. Other AGENT_LLM_* vars override per-container.
+if [ -z "$AGENT_LLM_KEY" ]; then
+    echo "run-task: AGENT_LLM_KEY not set — spawn this container via agentctl, or set llm_key in ~/.agentctl/config.json on the host" >&2
+    exit 1
+fi
+export ANTHROPIC_BASE_URL="${AGENT_LLM_BASE_URL:-http://host.containers.internal:8101}"
+export ANTHROPIC_AUTH_TOKEN="$AGENT_LLM_KEY"
+export ANTHROPIC_MODEL="${AGENT_LLM_MODEL:-local-code}"
+export ANTHROPIC_SMALL_FAST_MODEL="${AGENT_LLM_FAST_MODEL:-local-fast}"
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+exec claude --dangerously-skip-permissions --model "$ANTHROPIC_MODEL" -p "$@"

--- a/scripts/run-task
+++ b/scripts/run-task
@@ -1,15 +1,13 @@
 #!/bin/sh
-# Route the agent's Claude CLI through the mesh LLM router (LiteLLM on Odin :8101).
-# Default model: local-code (qwen2.5-coder on Loki GPU); router falls back to cloud-cheap.
-# AGENT_LLM_KEY is injected by agentctl spawn (host env or ~/.agentctl/config.json llm_key)
-# — never baked into the image. Other AGENT_LLM_* vars override per-container.
+# Agentic entrypoint: opencode → mesh LLM router (Odin :8101).
+# opencode speaks native OpenAI format, so tool calls pass through the router
+# intact (the claude-CLI /v1/messages path corrupted tool calls for non-Claude
+# backends — see mesh-status dogfood, 2026-07-03).
+# Default model: local-agent (qwen3:8b on Loki — structured tool calls verified).
+# AGENT_LLM_KEY is injected by agentctl spawn; AGENT_LLM_MODEL overrides per container.
 if [ -z "$AGENT_LLM_KEY" ]; then
     echo "run-task: AGENT_LLM_KEY not set — spawn this container via agentctl, or set llm_key in ~/.agentctl/config.json on the host" >&2
     exit 1
 fi
-export ANTHROPIC_BASE_URL="${AGENT_LLM_BASE_URL:-http://host.containers.internal:8101}"
-export ANTHROPIC_AUTH_TOKEN="$AGENT_LLM_KEY"
-export ANTHROPIC_MODEL="${AGENT_LLM_MODEL:-local-code}"
-export ANTHROPIC_SMALL_FAST_MODEL="${AGENT_LLM_FAST_MODEL:-local-fast}"
-export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-exec claude --dangerously-skip-permissions --model "$ANTHROPIC_MODEL" -p "$@"
+export AGENT_LLM_KEY
+exec opencode run -m "router/${AGENT_LLM_MODEL:-local-agent}" "$@"


### PR DESCRIPTION
## Summary
- `run-task` now points the image's Claude CLI at the LiteLLM router (Odin :8101) via `ANTHROPIC_BASE_URL`, defaulting to `local-code` (qwen2.5-coder:7b on Loki GPU); the router itself falls back to `cloud-cheap` if Loki is down.
- The router key is injected at spawn from `AGENT_LLM_KEY` env or `~/.agentctl/config.json` `llm_key` — never baked into the image.
- `AGENT_LLM_BASE_URL` / `AGENT_LLM_MODEL` / `AGENT_LLM_FAST_MODEL` override per container.
- Note: this replaces the `opencode/big-pickle` run-task from #31, which was never deployed (image still shipped the claude variant, and opencode isn't installed in the Dockerfile). If opencode is still the preferred direction, the router config here carries over — only the exec line changes.

## Testing
- `agent-devbox:latest` rebuilt with the new run-task; agentctl binary rebuilt and installed.
- Spawned a real container: key injected, `run-task 'Reply with exactly: CONTAINER-ROUTER-OK'` returned correctly in 9.6s.
- Confirmed qwen2.5-coder:7b resident in Loki VRAM serving the request (`/api/ps`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the task runner and container setup to use an Opencode mesh LLM router configuration, selecting models via `AGENT_LLM_MODEL` with sensible local aliases.
  * Container launches now inherit host `AGENT_LLM_*` settings (base URL and model variants) to keep routing consistent.
* **Bug Fixes**
  * Improved LLM key handling by requiring `AGENT_LLM_KEY` for router operation and injecting it only when present.
  * Removed automatic copying of Claude authentication files into the container; authentication is handled via the router key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->