### PR TITLE
feat: agentctl dispatch — one-command worker lifecycle

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -560,6 +560,10 @@ func main() {
 				i++
 			}
 		}
+		if code, msg := container.ValidateDispatchArgs(issue, intent, intentFile); code != 0 {
+			fmt.Fprintln(os.Stderr, msg)
+			os.Exit(code)
+		}
 		if err := container.Dispatch(name, repo, issue, intent, intentFile, model, branch, image); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -530,6 +530,41 @@ func main() {
 			os.Exit(1)
 		}
 
+	case "dispatch":
+		if len(os.Args) < 4 {
+			fmt.Println("Usage: agentctl dispatch <name> <repo> (--issue N | --intent TEXT | --intent-file PATH) [--model M] [--branch B] [--image I]")
+			os.Exit(1)
+		}
+		name := os.Args[2]
+		repo := os.Args[3]
+		issue, intent, intentFile, model, branch, image := "", "", "", "", "", ""
+		for i := 4; i < len(os.Args); i++ {
+			switch {
+			case os.Args[i] == "--issue" && i+1 < len(os.Args):
+				issue = os.Args[i+1]
+				i++
+			case os.Args[i] == "--intent" && i+1 < len(os.Args):
+				intent = os.Args[i+1]
+				i++
+			case os.Args[i] == "--intent-file" && i+1 < len(os.Args):
+				intentFile = os.Args[i+1]
+				i++
+			case os.Args[i] == "--model" && i+1 < len(os.Args):
+				model = os.Args[i+1]
+				i++
+			case os.Args[i] == "--branch" && i+1 < len(os.Args):
+				branch = os.Args[i+1]
+				i++
+			case os.Args[i] == "--image" && i+1 < len(os.Args):
+				image = os.Args[i+1]
+				i++
+			}
+		}
+		if err := container.Dispatch(name, repo, issue, intent, intentFile, model, branch, image); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
 	case "review":
 		// agentctl review <name>
 		if len(os.Args) < 3 {

--- a/pkg/container/agent.go
+++ b/pkg/container/agent.go
@@ -215,11 +215,27 @@ func Status(name string) error {
 	fmt.Printf("Repo: %s\n", agent.Repo)
 	fmt.Printf("Branch: %s\n", agent.Branch)
 	fmt.Printf("Created: %s\n", agent.Created.Format(time.RFC3339))
+	taskRun, _ := exec.Command("podman", "exec", name, "sh", "-c", "pgrep -f run-task || pgrep -f opencode || true").Output()
+	if strings.TrimSpace(string(taskRun)) != "" {
+		fmt.Println("task: running")
+	} else {
+		fmt.Println("task: exited")
+	}
+	if _, err := exec.Command("podman", "exec", name, "test", "-f", "/home/agent/task.log").CombinedOutput(); err == nil {
+		last, _ := exec.Command("podman", "exec", name, "tail", "-3", "/home/agent/task.log").Output()
+		fmt.Printf("task.log tail:\n%s", last)
+	}
 	return nil
 }
 
 // Logs shows Claude logs from the agent
 func Logs(name string) error {
+	if _, err := exec.Command("podman", "exec", name, "test", "-f", "/home/agent/task.log").CombinedOutput(); err == nil {
+		cmd := exec.Command("podman", "exec", name, "tail", "-50", "/home/agent/task.log")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
 	cmd := exec.Command("podman", "exec", name, "cat", "/home/agent/claude.log")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/container/dispatch.go
+++ b/pkg/container/dispatch.go
@@ -1,0 +1,117 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const DispatchPreamble = `Do ALL work yourself, directly in this session. Do NOT delegate to subagents or task agents — they do not receive this spec.
+
+Branch discipline:
+- Create a feature branch for this work.
+- Push the branch immediately upon creation.
+- Commit and push after every working increment.
+- Never include Co-Authored-By lines.
+
+PR instruction: When the task originates from a GitHub issue, open a PR to the base branch whose body includes "Closes #N".
+`
+
+func ValidateDispatchArgs(issue, intent, intentFile string) (int, string) {
+	count := 0
+	if issue != "" {
+		count++
+	}
+	if intent != "" {
+		count++
+	}
+	if intentFile != "" {
+		count++
+	}
+	if count == 0 {
+		return 64, "dispatch requires exactly one of --issue, --intent, or --intent-file"
+	}
+	if count > 1 {
+		return 64, "dispatch accepts only one intent source: --issue OR --intent OR --intent-file"
+	}
+	return 0, ""
+}
+
+func DefaultModel(m string) string {
+	if m == "" {
+		return "cloud-smart"
+	}
+	return m
+}
+
+func getHostGitIdentity() (string, string, error) {
+	nameOut, err := exec.Command("git", "config", "--get", "user.name").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("host git user.name not configured (fatal for dispatch identity)")
+	}
+	emailOut, err := exec.Command("git", "config", "--get", "user.email").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("host git user.email not configured (fatal for dispatch identity)")
+	}
+	return strings.TrimSpace(string(nameOut)), strings.TrimSpace(string(emailOut)), nil
+}
+
+func Dispatch(name, repo string, issue, intent, intentFile, model, branch, image string) error {
+	code, msg := ValidateDispatchArgs(issue, intent, intentFile)
+	if code != 0 {
+		fmt.Fprintln(os.Stderr, msg)
+		os.Exit(code)
+	}
+	model = DefaultModel(model)
+	if image == "" {
+		image = DefaultImage
+	}
+	_, err := Spawn(name, repo, branch, image)
+	if err != nil {
+		return err
+	}
+	if llmKey := resolveLLMKey(); llmKey != "" {
+		exec.Command("podman", "exec", name, "sh", "-c", fmt.Sprintf("echo 'export AGENT_LLM_KEY=%s' >> /home/agent/.bashrc", llmKey)).Run()
+	}
+	exec.Command("podman", "exec", name, "sh", "-c", fmt.Sprintf("echo 'export AGENT_LLM_MODEL=%s' >> /home/agent/.bashrc", model)).Run()
+
+	ownerRepo := repo
+	if strings.HasPrefix(repo, "https://") {
+		ownerRepo = strings.TrimSuffix(strings.TrimPrefix(repo, "https://github.com/"), ".git")
+	}
+	exec.Command("podman", "exec", name, "gh", "repo", "clone", ownerRepo, "/home/agent/workspace/repo").Run()
+	exec.Command("podman", "exec", name, "gh", "auth", "setup-git").Run()
+	if branch != "" {
+		exec.Command("podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "checkout", branch).Run()
+	}
+
+	gitName, gitEmail, err := getHostGitIdentity()
+	if err != nil {
+		return err
+	}
+	exec.Command("podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "config", "user.name", gitName).Run()
+	exec.Command("podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "config", "user.email", gitEmail).Run()
+
+	var fullIntent string
+	if issue != "" {
+		out, _ := exec.Command("gh", "issue", "view", issue, "-R", ownerRepo, "--json", "title,body").Output()
+		fullIntent = DispatchPreamble + "\nYou are working on GitHub issue #" + issue + " for " + ownerRepo + ": " + string(out)
+	} else if intent != "" {
+		fullIntent = DispatchPreamble + "\n" + intent
+	} else if intentFile != "" {
+		data, _ := os.ReadFile(intentFile)
+		fullIntent = DispatchPreamble + "\n" + string(data)
+	}
+	tmp := "/tmp/intent." + name + ".txt"
+	os.WriteFile(tmp, []byte(fullIntent), 0644)
+	exec.Command("podman", "cp", tmp, name+":/home/agent/intent.txt").Run()
+	os.Remove(tmp)
+
+	exec.Command("podman", "exec", "-d", "-w", "/home/agent/workspace/repo", name,
+		"sh", "-c", "run-task \"$(cat /home/agent/intent.txt)\" > /home/agent/task.log 2>&1").Run()
+
+	fmt.Printf("dispatched: %s\nmodel: %s   repo: %s   intent: %s\nfollow:  agentctl logs %s   (tails /home/agent/task.log)\nstatus:  agentctl status %s\n",
+		name, model, repo, map[bool]string{true: "issue #" + issue, false: "inline"}[issue != ""], name, name)
+	return nil
+}

--- a/pkg/container/dispatch.go
+++ b/pkg/container/dispatch.go
@@ -18,16 +18,14 @@ Branch discipline:
 PR instruction: When the task originates from a GitHub issue, open a PR to the base branch whose body includes "Closes #N".
 `
 
+// ValidateDispatchArgs enforces exactly one intent source. It only reports;
+// the exit decision belongs to the caller (main), never to a library function.
 func ValidateDispatchArgs(issue, intent, intentFile string) (int, string) {
 	count := 0
-	if issue != "" {
-		count++
-	}
-	if intent != "" {
-		count++
-	}
-	if intentFile != "" {
-		count++
+	for _, v := range []string{issue, intent, intentFile} {
+		if v != "" {
+			count++
+		}
 	}
 	if count == 0 {
 		return 64, "dispatch requires exactly one of --issue, --intent, or --intent-file"
@@ -45,6 +43,34 @@ func DefaultModel(m string) string {
 	return m
 }
 
+// IntentSource labels which source produced the intent, for the status line.
+func IntentSource(issue, intent, intentFile string) string {
+	switch {
+	case issue != "":
+		return "issue #" + issue
+	case intentFile != "":
+		return "intent-file"
+	default:
+		return "inline"
+	}
+}
+
+// ComposeIntent builds the full worker prompt. Pure function (issueJSON is the
+// raw `gh issue view --json title,body` output, fetched by the caller) so the
+// composition the spec requires tests for is testable without podman/gh.
+func ComposeIntent(issue, intent, intentFile, ownerRepo, issueJSON, fileContent string) string {
+	switch {
+	case issue != "":
+		return DispatchPreamble + "\nYou are working on GitHub issue #" + issue + " for " + ownerRepo + ": " + issueJSON
+	case intent != "":
+		return DispatchPreamble + "\n" + intent
+	case intentFile != "":
+		return DispatchPreamble + "\n" + fileContent
+	default:
+		return DispatchPreamble
+	}
+}
+
 func getHostGitIdentity() (string, string, error) {
 	nameOut, err := exec.Command("git", "config", "--get", "user.name").Output()
 	if err != nil {
@@ -57,61 +83,108 @@ func getHostGitIdentity() (string, string, error) {
 	return strings.TrimSpace(string(nameOut)), strings.TrimSpace(string(emailOut)), nil
 }
 
+func ownerRepoOf(repo string) string {
+	if strings.HasPrefix(repo, "https://") {
+		return strings.TrimSuffix(strings.TrimPrefix(repo, "https://github.com/"), ".git")
+	}
+	return repo
+}
+
+// run wraps podman/gh/git steps so failures surface with context instead of
+// vanishing. AGENT_LLM_KEY is NOT set here — Spawn already injects it as
+// container env, which podman exec inherits (a .bashrc echo would be both
+// redundant and a shell-injection vector).
+func run(step string, args ...string) error {
+	if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %v: %s", step, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 func Dispatch(name, repo string, issue, intent, intentFile, model, branch, image string) error {
-	code, msg := ValidateDispatchArgs(issue, intent, intentFile)
-	if code != 0 {
-		fmt.Fprintln(os.Stderr, msg)
-		os.Exit(code)
+	if code, msg := ValidateDispatchArgs(issue, intent, intentFile); code != 0 {
+		return fmt.Errorf("%s", msg)
 	}
 	model = DefaultModel(model)
 	if image == "" {
 		image = DefaultImage
 	}
-	_, err := Spawn(name, repo, branch, image)
-	if err != nil {
-		return err
-	}
-	if llmKey := resolveLLMKey(); llmKey != "" {
-		exec.Command("podman", "exec", name, "sh", "-c", fmt.Sprintf("echo 'export AGENT_LLM_KEY=%s' >> /home/agent/.bashrc", llmKey)).Run()
-	}
 
-	ownerRepo := repo
-	if strings.HasPrefix(repo, "https://") {
-		ownerRepo = strings.TrimSuffix(strings.TrimPrefix(repo, "https://github.com/"), ".git")
-	}
-	exec.Command("podman", "exec", name, "gh", "repo", "clone", ownerRepo, "/home/agent/workspace/repo").Run()
-	exec.Command("podman", "exec", name, "gh", "auth", "setup-git").Run()
-	if branch != "" {
-		exec.Command("podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "checkout", branch).Run()
-	}
-
+	// Resolve the git identity BEFORE spawning, so a missing identity fails
+	// without leaving an orphaned container running.
 	gitName, gitEmail, err := getHostGitIdentity()
 	if err != nil {
 		return err
 	}
-	exec.Command("podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "config", "user.name", gitName).Run()
-	exec.Command("podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "config", "user.email", gitEmail).Run()
 
-	var fullIntent string
-	if issue != "" {
-		out, _ := exec.Command("gh", "issue", "view", issue, "-R", ownerRepo, "--json", "title,body").Output()
-		fullIntent = DispatchPreamble + "\nYou are working on GitHub issue #" + issue + " for " + ownerRepo + ": " + string(out)
-	} else if intent != "" {
-		fullIntent = DispatchPreamble + "\n" + intent
-	} else if intentFile != "" {
-		data, _ := os.ReadFile(intentFile)
-		fullIntent = DispatchPreamble + "\n" + string(data)
+	if _, err := Spawn(name, repo, branch, image); err != nil {
+		return err
 	}
-	tmp := "/tmp/intent." + name + ".txt"
-	os.WriteFile(tmp, []byte(fullIntent), 0644)
-	exec.Command("podman", "cp", tmp, name+":/home/agent/intent.txt").Run()
-	os.Remove(tmp)
+	// From here, any error must reap the container so the caller isn't left
+	// with a half-provisioned worker.
+	fail := func(e error) error {
+		Kill(name)
+		return e
+	}
 
-	exec.Command("podman", "exec", "-d", "-w", "/home/agent/workspace/repo",
+	ownerRepo := ownerRepoOf(repo)
+	if err := run("gh clone", "podman", "exec", name, "gh", "repo", "clone", ownerRepo, "/home/agent/workspace/repo"); err != nil {
+		return fail(err)
+	}
+	if err := run("gh auth setup-git", "podman", "exec", name, "gh", "auth", "setup-git"); err != nil {
+		return fail(err)
+	}
+	if branch != "" {
+		if err := run("checkout", "podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "checkout", branch); err != nil {
+			return fail(err)
+		}
+	}
+	if err := run("git user.name", "podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "config", "user.name", gitName); err != nil {
+		return fail(err)
+	}
+	if err := run("git user.email", "podman", "exec", name, "git", "-C", "/home/agent/workspace/repo", "config", "user.email", gitEmail); err != nil {
+		return fail(err)
+	}
+
+	var issueJSON, fileContent string
+	if issue != "" {
+		out, err := exec.Command("gh", "issue", "view", issue, "-R", ownerRepo, "--json", "title,body").Output()
+		if err != nil {
+			return fail(fmt.Errorf("gh issue view %s: %v", issue, err))
+		}
+		issueJSON = string(out)
+	} else if intentFile != "" {
+		data, err := os.ReadFile(intentFile)
+		if err != nil {
+			return fail(fmt.Errorf("read intent file: %v", err))
+		}
+		fileContent = string(data)
+	}
+	fullIntent := ComposeIntent(issue, intent, intentFile, ownerRepo, issueJSON, fileContent)
+
+	// Private temp file (0600 via CreateTemp) instead of a predictable
+	// world-readable /tmp path — intent can contain sensitive task detail.
+	tmp, err := os.CreateTemp("", "agentctl-intent-*.txt")
+	if err != nil {
+		return fail(fmt.Errorf("create intent temp: %v", err))
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(fullIntent); err != nil {
+		tmp.Close()
+		return fail(fmt.Errorf("write intent temp: %v", err))
+	}
+	tmp.Close()
+	if err := run("cp intent", "podman", "cp", tmp.Name(), name+":/home/agent/intent.txt"); err != nil {
+		return fail(err)
+	}
+
+	if err := run("launch", "podman", "exec", "-d", "-w", "/home/agent/workspace/repo",
 		"-e", "AGENT_LLM_MODEL="+model, name,
-		"sh", "-c", "run-task \"$(cat /home/agent/intent.txt)\" > /home/agent/task.log 2>&1").Run()
+		"sh", "-c", "run-task \"$(cat /home/agent/intent.txt)\" > /home/agent/task.log 2>&1"); err != nil {
+		return fail(err)
+	}
 
 	fmt.Printf("dispatched: %s\nmodel: %s   repo: %s   intent: %s\nfollow:  agentctl logs %s   (tails /home/agent/task.log)\nstatus:  agentctl status %s\n",
-		name, model, repo, map[bool]string{true: "issue #" + issue, false: "inline"}[issue != ""], name, name)
+		name, model, repo, IntentSource(issue, intent, intentFile), name, name)
 	return nil
 }

--- a/pkg/container/dispatch.go
+++ b/pkg/container/dispatch.go
@@ -74,7 +74,6 @@ func Dispatch(name, repo string, issue, intent, intentFile, model, branch, image
 	if llmKey := resolveLLMKey(); llmKey != "" {
 		exec.Command("podman", "exec", name, "sh", "-c", fmt.Sprintf("echo 'export AGENT_LLM_KEY=%s' >> /home/agent/.bashrc", llmKey)).Run()
 	}
-	exec.Command("podman", "exec", name, "sh", "-c", fmt.Sprintf("echo 'export AGENT_LLM_MODEL=%s' >> /home/agent/.bashrc", model)).Run()
 
 	ownerRepo := repo
 	if strings.HasPrefix(repo, "https://") {
@@ -108,7 +107,8 @@ func Dispatch(name, repo string, issue, intent, intentFile, model, branch, image
 	exec.Command("podman", "cp", tmp, name+":/home/agent/intent.txt").Run()
 	os.Remove(tmp)
 
-	exec.Command("podman", "exec", "-d", "-w", "/home/agent/workspace/repo", name,
+	exec.Command("podman", "exec", "-d", "-w", "/home/agent/workspace/repo",
+		"-e", "AGENT_LLM_MODEL="+model, name,
 		"sh", "-c", "run-task \"$(cat /home/agent/intent.txt)\" > /home/agent/task.log 2>&1").Run()
 
 	fmt.Printf("dispatched: %s\nmodel: %s   repo: %s   intent: %s\nfollow:  agentctl logs %s   (tails /home/agent/task.log)\nstatus:  agentctl status %s\n",

--- a/pkg/container/dispatch_test.go
+++ b/pkg/container/dispatch_test.go
@@ -1,30 +1,20 @@
 package container
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestDispatchPreambleContainsNoSubagent(t *testing.T) {
-	if !contains(DispatchPreamble, "Do NOT delegate to subagents or task agents") {
+	if !strings.Contains(DispatchPreamble, "Do NOT delegate to subagents or task agents") {
 		t.Errorf("preamble missing no-subagent sentence")
 	}
 }
 
 func TestDispatchPreambleContainsPushEarly(t *testing.T) {
-	if !contains(DispatchPreamble, "Push the branch immediately upon creation") {
+	if !strings.Contains(DispatchPreamble, "Push the branch immediately upon creation") {
 		t.Errorf("preamble missing push-early discipline")
 	}
-}
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsHelper(s, sub))
-}
-
-func containsHelper(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }
 
 func TestValidateDispatchArgs(t *testing.T) {
@@ -45,5 +35,61 @@ func TestDefaultModel(t *testing.T) {
 	}
 	if DefaultModel("local-fast") != "local-fast" {
 		t.Errorf("explicit model preserved")
+	}
+}
+
+func TestIntentSource(t *testing.T) {
+	cases := []struct{ issue, intent, file, want string }{
+		{"5", "", "", "issue #5"},
+		{"", "do a thing", "", "inline"},
+		{"", "", "/path/spec.md", "intent-file"},
+	}
+	for _, c := range cases {
+		if got := IntentSource(c.issue, c.intent, c.file); got != c.want {
+			t.Errorf("IntentSource(%q,%q,%q) = %q, want %q", c.issue, c.intent, c.file, got, c.want)
+		}
+	}
+}
+
+func TestComposeIntentIssue(t *testing.T) {
+	got := ComposeIntent("7", "", "", "owner/repo", `{"title":"T","body":"B"}`, "")
+	if !strings.HasPrefix(got, DispatchPreamble) {
+		t.Errorf("composed intent must start with preamble")
+	}
+	if !strings.Contains(got, "issue #7 for owner/repo") {
+		t.Errorf("issue intent missing issue reference: %q", got)
+	}
+	if !strings.Contains(got, `"title":"T"`) {
+		t.Errorf("issue intent missing issue JSON")
+	}
+}
+
+func TestComposeIntentInline(t *testing.T) {
+	got := ComposeIntent("", "build the widget", "", "owner/repo", "", "")
+	if !strings.Contains(got, "build the widget") {
+		t.Errorf("inline intent missing text")
+	}
+	if strings.Contains(got, "issue #") {
+		t.Errorf("inline intent should not reference an issue")
+	}
+}
+
+func TestComposeIntentFile(t *testing.T) {
+	got := ComposeIntent("", "", "/spec.md", "owner/repo", "", "FILE SPEC BODY")
+	if !strings.Contains(got, "FILE SPEC BODY") {
+		t.Errorf("file intent missing file content")
+	}
+}
+
+func TestOwnerRepoOf(t *testing.T) {
+	cases := map[string]string{
+		"owner/repo":                          "owner/repo",
+		"https://github.com/owner/repo":       "owner/repo",
+		"https://github.com/owner/repo.git":   "owner/repo",
+	}
+	for in, want := range cases {
+		if got := ownerRepoOf(in); got != want {
+			t.Errorf("ownerRepoOf(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/pkg/container/dispatch_test.go
+++ b/pkg/container/dispatch_test.go
@@ -1,0 +1,49 @@
+package container
+
+import "testing"
+
+func TestDispatchPreambleContainsNoSubagent(t *testing.T) {
+	if !contains(DispatchPreamble, "Do NOT delegate to subagents or task agents") {
+		t.Errorf("preamble missing no-subagent sentence")
+	}
+}
+
+func TestDispatchPreambleContainsPushEarly(t *testing.T) {
+	if !contains(DispatchPreamble, "Push the branch immediately upon creation") {
+		t.Errorf("preamble missing push-early discipline")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsHelper(s, sub))
+}
+
+func containsHelper(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateDispatchArgs(t *testing.T) {
+	if code, _ := ValidateDispatchArgs("", "", ""); code != 64 {
+		t.Errorf("expected 64 for no source")
+	}
+	if code, _ := ValidateDispatchArgs("1", "text", ""); code != 64 {
+		t.Errorf("expected 64 for duplicate sources")
+	}
+	if code, _ := ValidateDispatchArgs("1", "", ""); code != 0 {
+		t.Errorf("expected 0 for valid --issue")
+	}
+}
+
+func TestDefaultModel(t *testing.T) {
+	if DefaultModel("") != "cloud-smart" {
+		t.Errorf("default model should be cloud-smart")
+	}
+	if DefaultModel("local-fast") != "local-fast" {
+		t.Errorf("explicit model preserved")
+	}
+}


### PR DESCRIPTION
Implements dispatch command per issue #33.

- podman exec -d detachment
- gh-based clone + gh auth setup-git (no token-URL)
- host git identity (loud fail)
- DispatchPreamble exported & tested
- AGENT_LLM_MODEL defaults to cloud-smart
- logs/status enhancements

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level `dispatch` CLI command to start work from an issue, inline intent, or intent file.
  * Enhanced `status` and `logs` to better indicate whether a task is running and to show recent task logs when available.
  * Dispatch now supports sensible defaults (e.g., model/image) and clearer startup messaging.
* **Bug Fixes**
  * Added stricter validation to reject missing or conflicting dispatch inputs (issue vs intent vs intent file).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->