### PR TITLE
fix: CleanupCompleted skips active containers (issue #35)

### DIFF
--- a/pkg/container/lifecycle.go
+++ b/pkg/container/lifecycle.go
@@ -256,7 +256,7 @@ func CleanupCompleted(gracePeriod time.Duration) ([]string, error) {
 
 	var cleaned []string
 	for _, a := range agents {
-		if a.Lifecycle == StateCompleted && a.Age > gracePeriod {
+		if a.Lifecycle == StateCompleted && !a.ContainerUp && a.Age > gracePeriod {
 			if err := Cleanup(a.Name, "success", 0, nil); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: failed to cleanup %s: %v\n", a.Name, err)
 				continue


### PR DESCRIPTION
Closes #35

CleanupCompleted previously reaped all containers in StateCompleted past the grace period, even when the container was still running. This fix adds an additional !a.ContainerUp guard so only completed agents that are no longer running get cleaned up.

This prevents the timer from killing still-working agents mid-task (the root cause of hopper-tests getting reaped at the 1h mark).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated formatting in a container cleanup check with no change to behavior.
  * No user-facing functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->